### PR TITLE
MM2Q promotion iterators

### DIFF
--- a/cachelib/allocator/MM2Q-inl.h
+++ b/cachelib/allocator/MM2Q-inl.h
@@ -243,15 +243,16 @@ MM2Q::Container<T, HookPtr>::getEvictionIterator() const noexcept {
   return Iterator{std::move(l), lru_.rbegin()};
 }
 
+
+// returns the head of the hot queue for promotion
 template <typename T, MM2Q::Hook<T> T::*HookPtr>
 template <typename F>
 void
-MM2Q::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+MM2Q::Container<T, HookPtr>::withPromotionIterator(F&& fun) {
   lruMutex_->lock_combine([this, &fun]() {
-    fun(Iterator{LockHolder{}, lru_.rbegin()});
+    fun(Iterator{LockHolder{}, lru_.begin(LruType::Hot)});
   });
 }
-
 
 template <typename T, MM2Q::Hook<T> T::*HookPtr>
 void MM2Q::Container<T, HookPtr>::removeLocked(T& node,

--- a/cachelib/allocator/MM2Q-inl.h
+++ b/cachelib/allocator/MM2Q-inl.h
@@ -243,6 +243,14 @@ MM2Q::Container<T, HookPtr>::getEvictionIterator() const noexcept {
   return Iterator{std::move(l), lru_.rbegin()};
 }
 
+template <typename T, MM2Q::Hook<T> T::*HookPtr>
+template <typename F>
+void
+MM2Q::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  lruMutex_->lock_combine([this, &fun]() {
+    fun(Iterator{LockHolder{}, lru_.rbegin()});
+  });
+}
 
 // returns the head of the hot queue for promotion
 template <typename T, MM2Q::Hook<T> T::*HookPtr>

--- a/cachelib/allocator/MM2Q.h
+++ b/cachelib/allocator/MM2Q.h
@@ -442,6 +442,11 @@ class MM2Q {
     // iterator passed as parameter.
     template <typename F>
     void withEvictionIterator(F&& f);
+    
+    // Execute provided function under container lock. Function gets
+    // iterator passed as parameter.
+    template <typename F>
+    void withPromotionIterator(F&& f);
 
     // get the current config as a copy
     Config getConfig() const;

--- a/cachelib/allocator/datastruct/DList.h
+++ b/cachelib/allocator/datastruct/DList.h
@@ -216,6 +216,10 @@ class DList {
       curr_ = dir_ == Direction::FROM_HEAD ? dlist_->head_ : dlist_->tail_;
     }
 
+    Direction getDirection() noexcept {
+        return dir_;
+    }
+
    protected:
     void goForward() noexcept;
     void goBackward() noexcept;

--- a/cachelib/allocator/datastruct/MultiDList-inl.h
+++ b/cachelib/allocator/datastruct/MultiDList-inl.h
@@ -81,7 +81,7 @@ void MultiDList<T, HookPtr>::Iterator::initToValidBeginFrom(
     ++index_;
   }
   currIter_ = index_ == mlist_.lists_.size()
-                  ? mlist_.lists_[0]->rend()
+                  ? mlist_.lists_[0]->begin()
                   : mlist_.lists_[index_]->begin();
 }
 

--- a/cachelib/allocator/datastruct/MultiDList-inl.h
+++ b/cachelib/allocator/datastruct/MultiDList-inl.h
@@ -76,12 +76,12 @@ void MultiDList<T, HookPtr>::Iterator::initToValidBeginFrom(
     size_t listIdx) noexcept {
   // Find the first non-empty list.
   index_ = listIdx;
-  while (index_ != std::numeric_limits<size_t>::max() &&
+  while (index_ != mlist_.lists_.size() &&
          mlist_.lists_[index_]->size() == 0) {
-    --index_;
+    ++index_;
   }
-  currIter_ = index_ == std::numeric_limits<size_t>::max()
-                  ? mlist_.lists_[0]->end()
+  currIter_ = index_ == mlist_.lists_.size()
+                  ? mlist_.lists_[mlist_.lists_.size()-1]->begin()
                   : mlist_.lists_[index_]->begin();
 }
 

--- a/cachelib/allocator/datastruct/MultiDList-inl.h
+++ b/cachelib/allocator/datastruct/MultiDList-inl.h
@@ -130,7 +130,7 @@ typename MultiDList<T, HookPtr>::Iterator MultiDList<T, HookPtr>::rbegin(
   if (listIdx >= lists_.size()) {
     throw std::invalid_argument("Invalid list index for MultiDList iterator.");
   }
-  return MultiDList<T, HookPtr>::Iterator(*this, listIdx);
+  return MultiDList<T, HookPtr>::Iterator(*this, listIdx, false);
 }
 
 template <typename T, DListHook<T> T::*HookPtr>

--- a/cachelib/allocator/datastruct/MultiDList-inl.h
+++ b/cachelib/allocator/datastruct/MultiDList-inl.h
@@ -81,7 +81,7 @@ void MultiDList<T, HookPtr>::Iterator::initToValidBeginFrom(
     ++index_;
   }
   currIter_ = index_ == mlist_.lists_.size()
-                  ? mlist_.lists_[mlist_.lists_.size()-1]->rend()
+                  ? mlist_.lists_[0]->rend()
                   : mlist_.lists_[index_]->begin();
 }
 

--- a/cachelib/allocator/datastruct/MultiDList-inl.h
+++ b/cachelib/allocator/datastruct/MultiDList-inl.h
@@ -81,7 +81,7 @@ void MultiDList<T, HookPtr>::Iterator::initToValidBeginFrom(
     ++index_;
   }
   currIter_ = index_ == mlist_.lists_.size()
-                  ? mlist_.lists_[mlist_.lists_.size()-1]->begin()
+                  ? mlist_.lists_[mlist_.lists_.size()-1]->rend()
                   : mlist_.lists_[index_]->begin();
 }
 

--- a/cachelib/allocator/datastruct/MultiDList-inl.h
+++ b/cachelib/allocator/datastruct/MultiDList-inl.h
@@ -25,12 +25,26 @@ void MultiDList<T, HookPtr>::Iterator::goForward() noexcept {
   }
   // Move iterator forward
   ++currIter_;
-  // If we land at the rend of this list, move to the previous list.
-  while (index_ != kInvalidIndex &&
-         currIter_ == mlist_.lists_[index_]->rend()) {
-    --index_;
-    if (index_ != kInvalidIndex) {
-      currIter_ = mlist_.lists_[index_]->rbegin();
+
+  if (currIter_.getDirection() == DListIterator::Direction::FROM_HEAD) {
+    // If we land at the rend of this list, move to the previous list.
+    while (index_ != kInvalidIndex && index_ != mlist_.lists_.size() &&
+           currIter_ == mlist_.lists_[index_]->end()) {
+      ++index_;
+      if (index_ != kInvalidIndex && index_ != mlist_.lists_.size()) {
+        currIter_ = mlist_.lists_[index_]->begin();
+      } else {
+          return;
+      }
+    }
+  } else {
+    // If we land at the rend of this list, move to the previous list.
+    while (index_ != kInvalidIndex &&
+           currIter_ == mlist_.lists_[index_]->rend()) {
+      --index_;
+      if (index_ != kInvalidIndex) {
+        currIter_ = mlist_.lists_[index_]->rbegin();
+      }
     }
   }
 }
@@ -80,7 +94,12 @@ void MultiDList<T, HookPtr>::Iterator::initToValidBeginFrom(
          mlist_.lists_[index_]->size() == 0) {
     ++index_;
   }
-  currIter_ = index_ == mlist_.lists_.size()
+  if (index_ == mlist_.lists_.size()) {
+    //we reached the end - we should get set to
+    //invalid index
+    index_ = std::numeric_limits<size_t>::max();
+  }
+  currIter_ = index_ == std::numeric_limits<size_t>::max()
                   ? mlist_.lists_[0]->begin()
                   : mlist_.lists_[index_]->begin();
 }

--- a/cachelib/allocator/datastruct/MultiDList-inl.h
+++ b/cachelib/allocator/datastruct/MultiDList-inl.h
@@ -72,6 +72,20 @@ void MultiDList<T, HookPtr>::Iterator::initToValidRBeginFrom(
 }
 
 template <typename T, DListHook<T> T::*HookPtr>
+void MultiDList<T, HookPtr>::Iterator::initToValidBeginFrom(
+    size_t listIdx) noexcept {
+  // Find the first non-empty list.
+  index_ = listIdx;
+  while (index_ != std::numeric_limits<size_t>::max() &&
+         mlist_.lists_[index_]->size() == 0) {
+    --index_;
+  }
+  currIter_ = index_ == std::numeric_limits<size_t>::max()
+                  ? mlist_.lists_[0]->end()
+                  : mlist_.lists_[index_]->begin();
+}
+
+template <typename T, DListHook<T> T::*HookPtr>
 typename MultiDList<T, HookPtr>::Iterator&
 MultiDList<T, HookPtr>::Iterator::operator++() noexcept {
   goForward();
@@ -98,6 +112,15 @@ typename MultiDList<T, HookPtr>::Iterator MultiDList<T, HookPtr>::rbegin(
     throw std::invalid_argument("Invalid list index for MultiDList iterator.");
   }
   return MultiDList<T, HookPtr>::Iterator(*this, listIdx);
+}
+
+template <typename T, DListHook<T> T::*HookPtr>
+typename MultiDList<T, HookPtr>::Iterator MultiDList<T, HookPtr>::begin(
+    size_t listIdx) const {
+  if (listIdx >= lists_.size()) {
+    throw std::invalid_argument("Invalid list index for MultiDList iterator.");
+  }
+  return MultiDList<T, HookPtr>::Iterator(*this, listIdx, true);
 }
 
 template <typename T, DListHook<T> T::*HookPtr>

--- a/cachelib/allocator/datastruct/MultiDList.h
+++ b/cachelib/allocator/datastruct/MultiDList.h
@@ -110,16 +110,6 @@ class MultiDList {
     }
 
     explicit Iterator(const MultiDList<T, HookPtr>& mlist,
-                      size_t listIdx) noexcept
-        : currIter_(mlist.lists_[mlist.lists_.size() - 1]->rbegin()),
-          mlist_(mlist) {
-      XDCHECK_LT(listIdx, mlist.lists_.size());
-      initToValidRBeginFrom(listIdx);
-      // We should either point to an element or the end() iterator
-      // which has an invalid index_.
-      XDCHECK(index_ == kInvalidIndex || currIter_.get() != nullptr);
-    }
-    explicit Iterator(const MultiDList<T, HookPtr>& mlist,
                       size_t listIdx, bool head) noexcept
         : currIter_(mlist.lists_[mlist.lists_.size() - 1]->rbegin()),
           mlist_(mlist) {

--- a/cachelib/allocator/datastruct/MultiDList.h
+++ b/cachelib/allocator/datastruct/MultiDList.h
@@ -131,7 +131,7 @@ class MultiDList {
       }
       // We should either point to an element or the end() iterator
       // which has an invalid index_.
-      XDCHECK(index_ == kInvalidIndex || currIter_.get() != nullptr);
+      XDCHECK(index_ == kInvalidIndex || index_ == mlist.lists_.size() || currIter_.get() != nullptr);
     }
     virtual ~Iterator() = default;
 

--- a/cachelib/allocator/datastruct/MultiDList.h
+++ b/cachelib/allocator/datastruct/MultiDList.h
@@ -119,6 +119,20 @@ class MultiDList {
       // which has an invalid index_.
       XDCHECK(index_ == kInvalidIndex || currIter_.get() != nullptr);
     }
+    explicit Iterator(const MultiDList<T, HookPtr>& mlist,
+                      size_t listIdx, bool head) noexcept
+        : currIter_(mlist.lists_[mlist.lists_.size() - 1]->rbegin()),
+          mlist_(mlist) {
+      XDCHECK_LT(listIdx, mlist.lists_.size());
+      if (head) {
+        initToValidBeginFrom(listIdx);
+      } else {
+        initToValidRBeginFrom(listIdx);
+      }
+      // We should either point to an element or the end() iterator
+      // which has an invalid index_.
+      XDCHECK(index_ == kInvalidIndex || currIter_.get() != nullptr);
+    }
     virtual ~Iterator() = default;
 
     // copyable and movable
@@ -169,6 +183,9 @@ class MultiDList {
 
     // reset iterator to the beginning of a speicific queue
     void initToValidRBeginFrom(size_t listIdx) noexcept;
+    
+    // reset iterator to the head of a specific queue
+    void initToValidBeginFrom(size_t listIdx) noexcept;
 
     // Index of current list
     size_t index_{0};
@@ -184,6 +201,9 @@ class MultiDList {
 
   // provides an iterator starting from the tail of a specific list.
   Iterator rbegin(size_t idx) const;
+  
+  // provides an iterator starting from the head of a specific list.
+  Iterator begin(size_t idx) const;
 
   // Iterator to compare against for the end.
   Iterator rend() const noexcept;

--- a/cachelib/allocator/tests/MM2QTest.cpp
+++ b/cachelib/allocator/tests/MM2QTest.cpp
@@ -219,6 +219,19 @@ void MMTypeTest<MMType>::testIterate(std::vector<std::unique_ptr<Node>>& nodes,
 }
 
 template <typename MMType>
+void MMTypeTest<MMType>::testIterateHot(std::vector<std::unique_ptr<Node>>& nodes,
+                                     Container& c) {
+  auto it = nodes.rbegin();
+  c.withPromotionIterator([&it,&c](auto &&it2q) {
+    while (it2q && c.isHot(*it2q)) {
+        ASSERT_EQ(it2q->getId(), (*it)->getId());
+        ++it2q;
+        ++it;
+    }
+  });
+}
+
+template <typename MMType>
 void MMTypeTest<MMType>::testMatch(std::string expected,
                                    MMTypeTest<MMType>::Container& c) {
   int index = -1;
@@ -231,6 +244,23 @@ void MMTypeTest<MMType>::testMatch(std::string expected,
         (c.isHot(*it2q) ? "H" : (c.isCold(*it2q) ? "C" : "W")));
     ++it2q;
   }
+  ASSERT_EQ(expected, actual);
+}
+
+template <typename MMType>
+void MMTypeTest<MMType>::testMatchHot(std::string expected,
+                                   MMTypeTest<MMType>::Container& c) {
+  int index = -1;
+  std::string actual;
+  c.withPromotionIterator([&c,&actual,&index](auto &&it2q) {
+    while (it2q) {
+      ++index;
+      actual += folly::stringPrintf(
+          "%d:%s, ", it2q->getId(),
+          (c.isHot(*it2q) ? "H" : (c.isCold(*it2q) ? "C" : "W")));
+      ++it2q;
+    }
+  });
   ASSERT_EQ(expected, actual);
 }
 
@@ -255,8 +285,11 @@ TEST_F(MM2QTest, DetailedTest) {
   }
 
   testIterate(nodes, c);
+  testIterateHot(nodes, c);
 
   testMatch("0:C, 1:C, 2:C, 3:C, 4:H, 5:H, ", c);
+  testMatchHot("5:H, 4:H, 3:C, 2:C, 1:C, 0:C, ", c);
+
   // Move 3 to top of the hot cache
   c.recordAccess(*(nodes[4]), AccessMode::kRead);
   testMatch("0:C, 1:C, 2:C, 3:C, 5:H, 4:H, ", c);

--- a/cachelib/allocator/tests/MMTypeTest.h
+++ b/cachelib/allocator/tests/MMTypeTest.h
@@ -147,7 +147,9 @@ class MMTypeTest : public testing::Test {
   void testRecordAccessBasic(Config c);
   void testSerializationBasic(Config c);
   void testIterate(std::vector<std::unique_ptr<Node>>& nodes, Container& c);
+  void testIterateHot(std::vector<std::unique_ptr<Node>>& nodes, Container& c);
   void testMatch(std::string expected, Container& c);
+  void testMatchHot(std::string expected, Container& c);
   size_t getListSize(const Container& c, typename MMType::LruType list);
 };
 


### PR DESCRIPTION
Hot queue iterator for 2Q. Will start at Hot queue and move to Warm queue if hot queue is exhausted. Useful for promotion semantics if using 2Q replacement. rebased on to develop and added some tests.

