### PR TITLE
Code coverage support for CacheLib

### DIFF
--- a/cachelib/CMakeLists.txt
+++ b/cachelib/CMakeLists.txt
@@ -85,6 +85,11 @@ set(CMAKE_MODULE_PATH
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+if(COVERAGE_ENABLED)
+  # Add code coverage
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
+endif()
+
 # include(fb_cxx_flags)
 message(STATUS "Update CXXFLAGS: ${CMAKE_CXX_FLAGS}")
 

--- a/run_code_coverage.sh
+++ b/run_code_coverage.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#Build CacheLib with flag -DCOVERAGE_ENABLED=ON
+
+# Track coverage
+lcov -c -i -b . -d . -o Coverage.baseline
+./run_tests.sh
+lcov -c -d . -b . -o Coverage.out
+lcov -a Coverage.baseline -a Coverage.out -o Coverage.combined
+
+# Generate report
+COVERAGE_DIR='coverage_report'
+genhtml Coverage.combined -o ${COVERAGE_DIR}
+COVERAGE_REPORT="${COVERAGE_DIR}.tgz"
+tar -zcvf ${COVERAGE_REPORT} ${COVERAGE_DIR}
+echo "Created coverage report ${COVERAGE_REPORT}"
+
+# Cleanup
+rm Coverage.baseline Coverage.out Coverage.combined
+rm -rf ${COVERAGE_DIR}


### PR DESCRIPTION
Packages needed are lcov and genhtml.
Coverage requires addition of new compile and linker flags. It can be encapsulated as an option. Currently it is the hard-coded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/cachelib/50)
<!-- Reviewable:end -->
