### PR TITLE
Fix race in acquire

### DIFF
--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -2250,7 +2250,7 @@ auto& mmContainer = getMMContainer(tid, pid, cid);
 
   size_t memoryTierSize(TierId tid) const;
 
-  WriteHandle handleWithWaitContextForMovingItem(Item& item);
+  bool tryGetHandleWithWaitContextForMovingItem(Item& item, WriteHandle& handle);
 
   size_t wakeUpWaitersLocked(folly::StringPiece key, WriteHandle&& handle);
 


### PR DESCRIPTION
The assumption for moving items was that once item is unmarked no one can add new waiters for that item. However, since incrementing item ref count was not done under the MoveMap lock, there was a race: item could have been unmarked right after incRef returned incFailedMoving.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/CacheLib/68)
<!-- Reviewable:end -->
