### PR TITLE
Per tier pool stats

### DIFF
--- a/cachelib/allocator/Cache.cpp
+++ b/cachelib/allocator/Cache.cpp
@@ -235,17 +235,18 @@ void CacheBase::updateGlobalCacheStats(const std::string& statPrefix) const {
       statPrefix + "cache.size.configured",
       memStats.configuredRamCacheSize + memStats.nvmCacheSize);
 
+  //TODO: add specific per-tier counters
   const auto stats = getGlobalCacheStats();
   counters_.updateDelta(statPrefix + "cache.alloc_attempts",
-                        stats.allocAttempts);
+                        std::accumulate(stats.allocAttempts.begin(), stats.allocAttempts.end(),0));
   counters_.updateDelta(statPrefix + "cache.eviction_attempts",
-                        stats.evictionAttempts);
+                        std::accumulate(stats.evictionAttempts.begin(),stats.evictionAttempts.end(),0));
   counters_.updateDelta(statPrefix + "cache.alloc_failures",
-                        stats.allocFailures);
+                        std::accumulate(stats.allocFailures.begin(),stats.allocFailures.end(),0));
   counters_.updateDelta(statPrefix + "cache.invalid_allocs",
                         stats.invalidAllocs);
   const std::string ramEvictionKey = statPrefix + "ram.evictions";
-  counters_.updateDelta(ramEvictionKey, stats.numEvictions);
+  counters_.updateDelta(ramEvictionKey, std::accumulate(stats.numEvictions.begin(),stats.numEvictions.end(),0));
   // get the new delta to see if uploading any eviction age stats or lifetime
   // stats makes sense.
   uint64_t ramEvictionDelta = counters_.getDelta(ramEvictionKey);

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -1233,6 +1233,8 @@ class CacheAllocator : public CacheBase {
 
   // pool stats by pool id
   PoolStats getPoolStats(PoolId pid) const override final;
+  // pool stats by tier id and pool id
+  PoolStats getPoolStats(TierId tid, PoolId pid) const;
 
   // This can be expensive so it is not part of PoolStats
   PoolEvictionAgeStats getPoolEvictionAgeStats(
@@ -2015,9 +2017,9 @@ auto& mmContainer = getMMContainer(tid, pid, cid);
       XDCHECK(!candidate->isMarkedForEviction() && !candidate->isMoving());
 
       if (candidate->hasChainedItem()) {
-        (*stats_.chainedItemEvictions)[pid][cid].inc();
+        (*stats_.chainedItemEvictions)[tid][pid][cid].inc();
       } else {
-        (*stats_.regularItemEvictions)[pid][cid].inc();
+        (*stats_.regularItemEvictions)[tid][pid][cid].inc();
       }
 
       // it's safe to recycle the item here as there are no more

--- a/cachelib/allocator/CacheStats.cpp
+++ b/cachelib/allocator/CacheStats.cpp
@@ -23,18 +23,21 @@ namespace cachelib {
 namespace detail {
 
 void Stats::init() {
-  cacheHits = std::make_unique<PerPoolClassTLCounters>();
-  allocAttempts = std::make_unique<PerPoolClassAtomicCounters>();
-  evictionAttempts = std::make_unique<PerPoolClassAtomicCounters>();
-  fragmentationSize = std::make_unique<PerPoolClassAtomicCounters>();
-  allocFailures = std::make_unique<PerPoolClassAtomicCounters>();
-  chainedItemEvictions = std::make_unique<PerPoolClassAtomicCounters>();
-  regularItemEvictions = std::make_unique<PerPoolClassAtomicCounters>();
+  cacheHits = std::make_unique<PerTierPerPoolClassTLCounters>();
+  allocAttempts = std::make_unique<PerTierPerPoolClassAtomicCounters>();
+  evictionAttempts = std::make_unique<PerTierPerPoolClassAtomicCounters>();
+  fragmentationSize = std::make_unique<PerTierPerPoolClassAtomicCounters>();
+  allocFailures = std::make_unique<PerTierPerPoolClassAtomicCounters>();
+  chainedItemEvictions = std::make_unique<PerTierPerPoolClassAtomicCounters>();
+  regularItemEvictions = std::make_unique<PerTierPerPoolClassAtomicCounters>();
+  numWritebacks = std::make_unique<PerTierPerPoolClassAtomicCounters>();
   auto initToZero = [](auto& a) {
-    for (auto& s : a) {
-      for (auto& c : s) {
+    for (auto& t : a) {
+     for (auto& p : t) {
+      for (auto& c : p) {
         c.set(0);
       }
+     }
     }
   };
 
@@ -44,6 +47,7 @@ void Stats::init() {
   initToZero(*fragmentationSize);
   initToZero(*chainedItemEvictions);
   initToZero(*regularItemEvictions);
+  initToZero(*numWritebacks);
 
   classAllocLatency = std::make_unique<PerTierPoolClassRollingStats>();
 }
@@ -116,20 +120,43 @@ void Stats::populateGlobalCacheStats(GlobalCacheStats& ret) const {
   ret.nvmEvictionSecondsToExpiry = this->nvmEvictionSecondsToExpiry_.estimate();
   ret.nvmPutSize = this->nvmPutSize_.estimate();
 
-  auto accum = [](const PerPoolClassAtomicCounters& c) {
-    uint64_t sum = 0;
-    for (const auto& x : c) {
-      for (const auto& v : x) {
-        sum += v.get();
-      }
+  auto accum = [](const PerTierPerPoolClassAtomicCounters& t) {
+    std::vector<uint64_t> stat;
+    for (const auto& c : t) {
+     uint64_t sum = 0;
+     for (const auto& x : c) {
+       for (const auto& v : x) {
+         sum += v.get();
+       }
+     }
+     stat.push_back(sum);
     }
-    return sum;
+    return stat;
+  };
+
+  auto accumTL = [](const PerTierPerPoolClassTLCounters& t) {
+    std::vector<uint64_t> stat;
+    for (const auto& c : t) {
+     uint64_t sum = 0;
+     for (const auto& x : c) {
+       for (const auto& v : x) {
+         sum += v.get();
+       }
+     }
+     stat.push_back(sum);
+    }
+    return stat;
   };
   ret.allocAttempts = accum(*allocAttempts);
   ret.evictionAttempts = accum(*evictionAttempts);
   ret.allocFailures = accum(*allocFailures);
-  ret.numEvictions = accum(*chainedItemEvictions);
-  ret.numEvictions += accum(*regularItemEvictions);
+  auto chainedEvictions = accum(*chainedItemEvictions);
+  auto regularEvictions = accum(*regularItemEvictions);
+  for (TierId tid = 0; tid < chainedEvictions.size(); tid++) {
+    ret.numEvictions.push_back(chainedEvictions[tid] + regularEvictions[tid]);
+  }
+  ret.numWritebacks = accum(*numWritebacks);
+  ret.numCacheHits = accumTL(*cacheHits);
 
   ret.invalidAllocs = invalidAllocs.get();
   ret.numRefcountOverflow = numRefcountOverflow.get();
@@ -144,6 +171,18 @@ void Stats::populateGlobalCacheStats(GlobalCacheStats& ret) const {
 }
 
 } // namespace detail
+
+MMContainerStat& MMContainerStat::operator+=(const MMContainerStat& other) {
+
+  size += other.size;
+  oldestTimeSec = std::min(oldestTimeSec,other.oldestTimeSec);
+  lruRefreshTime = std::max(lruRefreshTime,other.lruRefreshTime);
+  numHotAccesses += other.numHotAccesses;
+  numColdAccesses += other.numColdAccesses;
+  numWarmAccesses += other.numWarmAccesses;
+  numTailAccesses += other.numTailAccesses;
+  return *this;
+}
 
 PoolStats& PoolStats::operator+=(const PoolStats& other) {
   auto verify = [](bool isCompatible) {
@@ -182,6 +221,7 @@ PoolStats& PoolStats::operator+=(const PoolStats& other) {
       d.allocFailures += s.allocFailures;
       d.fragmentationSize += s.fragmentationSize;
       d.numHits += s.numHits;
+      d.numWritebacks += s.numWritebacks;
       d.chainedItemEvictions += s.chainedItemEvictions;
       d.regularItemEvictions += s.regularItemEvictions;
     }
@@ -237,10 +277,26 @@ uint64_t PoolStats::numEvictions() const noexcept {
   return n;
 }
 
+uint64_t PoolStats::numWritebacks() const noexcept {
+  uint64_t n = 0;
+  for (const auto& s : cacheStats) {
+    n += s.second.numWritebacks;
+  }
+  return n;
+}
+
 uint64_t PoolStats::numItems() const noexcept {
   uint64_t n = 0;
   for (const auto& s : cacheStats) {
     n += s.second.numItems();
+  }
+  return n;
+}
+
+uint64_t PoolStats::numHits() const noexcept {
+  uint64_t n = 0;
+  for (const auto& s : cacheStats) {
+    n += s.second.numHits;
   }
   return n;
 }

--- a/cachelib/allocator/CacheStatsInternal.h
+++ b/cachelib/allocator/CacheStatsInternal.h
@@ -212,23 +212,26 @@ struct Stats {
   // we're currently writing into flash.
   mutable util::PercentileStats nvmPutSize_;
 
-  using PerPoolClassAtomicCounters =
+  using PerTierPerPoolClassAtomicCounters = std::array<
       std::array<std::array<AtomicCounter, MemoryAllocator::kMaxClasses>,
-                 MemoryPoolManager::kMaxPools>;
+                 MemoryPoolManager::kMaxPools>,
+      CacheBase::kMaxTiers>;
 
   // count of a stat for a specific allocation class
-  using PerPoolClassTLCounters =
+  using PerTierPerPoolClassTLCounters = std::array<
       std::array<std::array<TLCounter, MemoryAllocator::kMaxClasses>,
-                 MemoryPoolManager::kMaxPools>;
+                 MemoryPoolManager::kMaxPools>,
+      CacheBase::kMaxTiers>;
 
   // hit count for every alloc class in every pool
-  std::unique_ptr<PerPoolClassTLCounters> cacheHits{};
-  std::unique_ptr<PerPoolClassAtomicCounters> allocAttempts{};
-  std::unique_ptr<PerPoolClassAtomicCounters> evictionAttempts{};
-  std::unique_ptr<PerPoolClassAtomicCounters> allocFailures{};
-  std::unique_ptr<PerPoolClassAtomicCounters> fragmentationSize{};
-  std::unique_ptr<PerPoolClassAtomicCounters> chainedItemEvictions{};
-  std::unique_ptr<PerPoolClassAtomicCounters> regularItemEvictions{};
+  std::unique_ptr<PerTierPerPoolClassTLCounters> cacheHits{};
+  std::unique_ptr<PerTierPerPoolClassAtomicCounters> allocAttempts{};
+  std::unique_ptr<PerTierPerPoolClassAtomicCounters> evictionAttempts{};
+  std::unique_ptr<PerTierPerPoolClassAtomicCounters> allocFailures{};
+  std::unique_ptr<PerTierPerPoolClassAtomicCounters> fragmentationSize{};
+  std::unique_ptr<PerTierPerPoolClassAtomicCounters> chainedItemEvictions{};
+  std::unique_ptr<PerTierPerPoolClassAtomicCounters> regularItemEvictions{};
+  std::unique_ptr<PerTierPerPoolClassAtomicCounters> numWritebacks{};
 
   using PerTierPoolClassRollingStats = std::array<
       std::array<std::array<util::RollingStats, MemoryAllocator::kMaxClasses>,

--- a/cachelib/allocator/tests/AllocatorMemoryTiersTest.cpp
+++ b/cachelib/allocator/tests/AllocatorMemoryTiersTest.cpp
@@ -25,6 +25,7 @@ using LruAllocatorMemoryTiersTest = AllocatorMemoryTiersTest<LruAllocator>;
 // TODO(MEMORY_TIER): add more tests with different eviction policies
 TEST_F(LruAllocatorMemoryTiersTest, MultiTiersInvalid) { this->testMultiTiersInvalid(); }
 TEST_F(LruAllocatorMemoryTiersTest, MultiTiersValid) { this->testMultiTiersValid(); }
+TEST_F(LruAllocatorMemoryTiersTest, MultiTiersValidStats) { this->testMultiTiersValidStats(); }
 TEST_F(LruAllocatorMemoryTiersTest, MultiTiersValidMixed) { this->testMultiTiersValidMixed(); }
 TEST_F(LruAllocatorMemoryTiersTest, MultiTiersBackgroundMovers ) { this->testMultiTiersBackgroundMovers(); }
 TEST_F(LruAllocatorMemoryTiersTest, MultiTiersRemoveDuringEviction) { this->testMultiTiersRemoveDuringEviction(); }

--- a/cachelib/allocator/tests/TestBase-inl.h
+++ b/cachelib/allocator/tests/TestBase-inl.h
@@ -99,6 +99,30 @@ void AllocatorTest<AllocatorT>::fillUpPoolUntilEvictions(
 }
 
 template <typename AllocatorT>
+void AllocatorTest<AllocatorT>::fillUpPoolUntilEvictions(
+    AllocatorT& alloc,
+    TierId tid,
+    PoolId poolId,
+    const std::vector<uint32_t>& sizes,
+    unsigned int keyLen) {
+  unsigned int allocs = 0;
+  do {
+    allocs = 0;
+    for (const auto size : sizes) {
+      const auto key = getRandomNewKey(alloc, keyLen);
+      ASSERT_EQ(alloc.find(key), nullptr);
+      const size_t prev = alloc.getPoolByTid(poolId, tid).getCurrentAllocSize();
+      auto handle = util::allocateAccessible(alloc, poolId, key, size);
+      if (handle && prev != alloc.getPoolByTid(poolId, tid).getCurrentAllocSize()) {
+        // this means we did not cause an eviction.
+        ASSERT_GE(handle->getSize(), size);
+        allocs++;
+      }
+    }
+  } while (allocs != 0);
+}
+
+template <typename AllocatorT>
 void AllocatorTest<AllocatorT>::testAllocWithoutEviction(
     AllocatorT& alloc,
     PoolId poolId,

--- a/cachelib/allocator/tests/TestBase.h
+++ b/cachelib/allocator/tests/TestBase.h
@@ -69,6 +69,11 @@ class AllocatorTest : public SlabAllocatorTestBase {
                                 PoolId pid,
                                 const std::vector<uint32_t>& sizes,
                                 unsigned int keyLen);
+  void fillUpPoolUntilEvictions(AllocatorT& alloc,
+                                TierId tid,
+                                PoolId pid,
+                                const std::vector<uint32_t>& sizes,
+                                unsigned int keyLen);
   void fillUpOneSlab(AllocatorT& alloc,
                      PoolId poolId,
                      const uint32_t size,


### PR DESCRIPTION
This PR adds per tier statistics to the pool stats. We also introduce a new statistic called `writebacks` which counts the number of successfully moved items to the next tier.

Cachebench now outputs per tier hit ratios and per tier item counts so we can get a better idea of how much data is being served from each tier. 

I have verified that there is no impact to performance with this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/CacheLib/70)
<!-- Reviewable:end -->
