### PR TITLE
Child-item synchronization

### DIFF
--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -491,7 +491,7 @@ CacheAllocator<CacheTrait>::allocateChainedItem(const ReadHandle& parent,
         "Cannot call allocate chained item with a empty parent handle!");
   }
 
-  auto it = allocateChainedItemInternal(parent, size);
+  auto it = allocateChainedItemInternal(parent, size, getTierId(*parent), false); // TODO pass fromBgThread here
   if (auto eventTracker = getEventTracker()) {
     const auto result =
         it ? AllocatorApiResult::ALLOCATED : AllocatorApiResult::FAILED;
@@ -504,16 +504,13 @@ CacheAllocator<CacheTrait>::allocateChainedItem(const ReadHandle& parent,
 template <typename CacheTrait>
 typename CacheAllocator<CacheTrait>::WriteHandle
 CacheAllocator<CacheTrait>::allocateChainedItemInternal(
-    const ReadHandle& parent, uint32_t size) {
+    const ReadHandle& parent, uint32_t size, TierId tid, bool fromBgThread) {
   util::LatencyTracker tracker{stats().allocateLatency_};
 
   SCOPE_FAIL { stats_.invalidAllocs.inc(); };
 
   // number of bytes required for this item
   const auto requiredSize = ChainedItem::getRequiredSize(size);
-
-  // TODO: is this correct?
-  auto tid = getTierId(*parent);
 
   const auto pid = allocator_[tid]->getAllocInfo(parent->getMemory()).poolId;
   const auto cid = allocator_[tid]->getAllocationClassId(pid, requiredSize);
@@ -531,6 +528,8 @@ CacheAllocator<CacheTrait>::allocateChainedItemInternal(
     (*stats_.allocFailures)[tid][pid][cid].inc();
     return WriteHandle{};
   }
+
+  // TODO: wakeup BG
 
   SCOPE_FAIL { allocator_[tid]->free(memory); };
 
@@ -576,13 +575,6 @@ void CacheAllocator<CacheTrait>::addChainedItem(WriteHandle& parent,
   // Count a new child
   stats_.numChainedChildItems.inc();
 
-  // Increment refcount since this chained item is now owned by the parent
-  // Parent will decrement the refcount upon release. Since this is an
-  // internal refcount, we dont include it in active handle tracking.
-  auto ret = child->incRef(true);
-  XDCHECK(ret == RefcountWithFlags::incResult::incOk);
-  XDCHECK_EQ(2u, child->getRefCount());
-
   insertInMMContainer(*child);
 
   invalidateNvm(*parent);
@@ -621,8 +613,6 @@ CacheAllocator<CacheTrait>::popChainedItem(WriteHandle& parent) {
   const auto res = removeFromMMContainer(*head);
   XDCHECK(res == true);
 
-  // decrement the refcount to indicate this item is unlinked from its parent
-  head->decRef();
   stats_.numChainedChildItems.dec();
 
   if (auto eventTracker = getEventTracker()) {
@@ -769,7 +759,6 @@ CacheAllocator<CacheTrait>::replaceChainedItemLocked(Item& oldItem,
                                                      WriteHandle newItemHdl,
                                                      const Item& parent) {
   XDCHECK(newItemHdl != nullptr);
-  XDCHECK_GE(1u, oldItem.getRefCount());
 
   // grab the handle to the old item so that we can return this. Also, we need
   // to drop the refcount the parent holds on oldItem by manually calling
@@ -819,17 +808,6 @@ CacheAllocator<CacheTrait>::replaceChainedItemLocked(Item& oldItem,
       oldItem.asChainedItem().getNext(compressor_), compressor_);
   oldItem.asChainedItem().setNext(nullptr, compressor_);
 
-  // this should not result in 0 refcount. We are bumping down the internal
-  // refcount. If it did, we would leak an item.
-  oldItem.decRef();
-  XDCHECK_LT(0u, oldItem.getRefCount()) << oldItem.toString();
-
-  // increment refcount to indicate parent owns this similar to addChainedItem
-  // Since this is an internal refcount, we dont include it in active handle
-  // tracking.
-
-  auto ret = newItemHdl->incRef(true);
-  XDCHECK(ret == RefcountWithFlags::incResult::incOk);
   return oldItemHdl;
 }
 
@@ -858,26 +836,14 @@ CacheAllocator<CacheTrait>::releaseBackToAllocator(Item& it,
   (*stats_.fragmentationSize)[tid][allocInfo.poolId][allocInfo.classId].sub(
       util::getFragmentation(*this, it));
 
-  // Chained items can only end up in this place if the user has allocated
-  // memory for a chained item but has decided not to insert the chained item
-  // to a parent item and instead drop the chained item handle. In this case,
-  // we free the chained item directly without calling remove callback.
-  if (it.isChainedItem()) {
-    if (toRecycle) {
-      throw std::runtime_error(
-          folly::sformat("Can not recycle a chained item {}, toRecyle",
-                         it.toString(), toRecycle->toString()));
-    }
-    allocator_[tid]->free(&it);
-    return ReleaseRes::kReleased;
-  }
-
   // nascent items represent items that were allocated but never inserted into
   // the cache. We should not be executing removeCB for them since they were
   // not initialized from the user perspective and never part of the cache.
   if (!nascent && config_.removeCb) {
     config_.removeCb(RemoveCbData{ctx, it, viewAsChainedAllocsRange(it)});
   }
+
+  // TODO: should we call destructor for chained item? (Probably not)
 
   // only skip destructor for evicted items that are either in the queue to put
   // into nvm or already in nvm
@@ -942,31 +908,11 @@ CacheAllocator<CacheTrait>::releaseBackToAllocator(Item& it,
           util::getFragmentation(*this, *head));
 
       removeFromMMContainer(*head);
-
-      // If this chained item is marked as moving, we will not free it.
-      // We must capture the moving state before we do the decRef when
-      // we know the item must still be valid. Item cannot be marked as
-      // exclusive. Only parent can be marked as such and even parent needs
-      // to be unmark prior to calling releaseBackToAllocator.
-      const bool wasMoving = head->isMoving();
       XDCHECK(!head->isMarkedForEviction());
 
-      // Decref and check if we were the last reference. Now if the item
-      // was marked moving, after decRef, it will be free to be released
-      // by slab release thread
-      const auto childRef = head->decRef();
-
-      // If the item is already moving and we already decremented the
-      // refcount, we don't need to free this item. We'll let the slab
-      // release thread take care of that
-      if (!wasMoving) {
-        if (childRef != 0) {
-          throw std::runtime_error(folly::sformat(
-              "chained item refcount is not zero. We cannot proceed! "
-              "Ref: {}, Chained Item: {}",
-              childRef, head->toString()));
-        }
-
+      // Just skip 'moving' items. They will be discarded by the thread that started the move.
+      // Once that thread realises the parent is marked for eviction, it will just drop the item.
+      if(!head->isMoving()) {
         // Item is not moving and refcount is 0, we can proceed to
         // free it or recylce the memory
         if (head == toRecycle) {
@@ -1050,6 +996,7 @@ void CacheAllocator<CacheTrait>::release(Item* it, bool isNascent) {
   const auto ref = decRef(*it);
 
   if (UNLIKELY(ref == 0)) {
+    XDCHECK(!it->isChainedItem());
     const auto res =
         releaseBackToAllocator(*it, RemoveContext::kNormal, isNascent);
     XDCHECK(res == ReleaseRes::kReleased);
@@ -1473,6 +1420,8 @@ bool CacheAllocator<CacheTrait>::moveChainedItem(ChainedItem& oldItem,
 
   // This item has been unlinked from its parent and we're the only
   // owner of it, so we're done here
+
+  // TODO: unnecessary check now?
   if (!oldItem.isInMMContainer() || oldItem.isOnlyMoving()) {
     return false;
   }
@@ -1481,7 +1430,7 @@ bool CacheAllocator<CacheTrait>::moveChainedItem(ChainedItem& oldItem,
   const auto parentKey = expectedParent.getKey();
   auto l = chainedItemLocks_.lockExclusive(parentKey);
 
-  // verify old item under the lock
+  // Verify old item under the lock. This will synchronize with any potential eviction.
   auto parentHandle =
       validateAndGetParentHandleForChainedMoveLocked(oldItem, parentKey);
   if (!parentHandle || &expectedParent != parentHandle.get()) {
@@ -1504,6 +1453,8 @@ bool CacheAllocator<CacheTrait>::moveChainedItem(ChainedItem& oldItem,
 
   // In case someone else had removed this chained item from its parent by now
   // So we check again to see if the it has been unlinked from its parent
+
+  // TODO: unnecessary check now?
   if (!oldItem.isInMMContainer() || oldItem.isOnlyMoving()) {
     return false;
   }
@@ -1512,6 +1463,10 @@ bool CacheAllocator<CacheTrait>::moveChainedItem(ChainedItem& oldItem,
 
   XDCHECK_EQ(reinterpret_cast<uintptr_t>(parentPtr),
              reinterpret_cast<uintptr_t>(&oldItem.getParentItem(compressor_)));
+
+  // Unmark the item so we can grab a handle. It's safe since we're under the lock.
+  oldItem.unmarkMoving();
+  wakeUpWaiters(oldItem, acquire(&oldItem));
 
   // Invoke the move callback to fix up any user data related to the chain
   config_.moveCb(oldItem, *newItemHdl, parentPtr);
@@ -1561,10 +1516,11 @@ CacheAllocator<CacheTrait>::findEviction(TierId tid, PoolId pid, ClassId cid) {
     Item* toRecycle = nullptr;
     Item* candidate = nullptr;
     typename NvmCacheT::PutToken token;
+    WriteHandle parentHandle = nullptr;
 
     mmContainer.withEvictionIterator([this, tid, pid, cid, &candidate, &toRecycle,
                                       &searchTries, &mmContainer, &lastTier,
-                                      &token](auto&& itr) {
+                                      &token, &parentHandle](auto&& itr) {
       if (!itr) {
         ++searchTries;
         (*stats_.evictionAttempts)[tid][pid][cid].inc();
@@ -1579,21 +1535,16 @@ CacheAllocator<CacheTrait>::findEviction(TierId tid, PoolId pid, ClassId cid) {
 
         auto* toRecycle_ = itr.get();
         auto* candidate_ =
-            toRecycle_->isChainedItem()
+            toRecycle_->isChainedItem() && lastTier
                 ? &toRecycle_->asChainedItem().getParentItem(compressor_)
                 : toRecycle_;
-
-        if (lastTier) {
-          // if it's last tier, the item will be evicted
-          // need to create put token before marking it exclusive
-          token = createPutToken(*candidate_);
-        }
 
         if (lastTier && shouldWriteToNvmCache(*candidate_) && !token.isValid()) {
           stats_.evictFailConcurrentFill.inc();
         } else if ( (lastTier && candidate_->markForEviction()) ||
                     (!lastTier && candidate_->markMoving()) ) {
-          XDCHECK(candidate_->isMoving() || candidate_->isMarkedForEviction());
+          XDCHECK(candidate_->isMoving() || candidate_->isMarkedForEviction())
+
           // markForEviction to make sure no other thead is evicting the item
           // nor holding a handle to that item if this is last tier
           // since we won't be moving the item to the next tier
@@ -1655,8 +1606,35 @@ CacheAllocator<CacheTrait>::findEviction(TierId tid, PoolId pid, ClassId cid) {
       // as exclusive since we will not be moving the item to the next tier
       // but rather just evicting all together, no need to
       // markForEvictionWhenMoving
-      auto ret = lastTier ? true : candidate->markForEvictionWhenMoving();
-      XDCHECK(ret);
+
+      if (candidate->isChainedItem()) {
+        // For chained item only case (b) above can happen.
+        // replaceChaineItem will acquire handle to the old item
+        // before doing anything else
+
+        auto child = candidate;
+        candidate = &candidate->asChainedItem().getParentItem(compressor_);
+
+        auto ret = candidate->markForEviction();
+
+        if (!ret) {
+          child->unmarkMoving();
+
+          // TODO: we need to wakeupWaiters, but what should we pass here?
+          // We would need to have a way to atomically unmarkMoving and get a handle
+
+          // TODO: Add unmarkMovingAndIncRef()? OR GRAB A chainedItemLocks_ HERE?
+
+          continue;
+        } else {
+          // No need to wakeup anynone, if markForEviction succeede, there is no one waiting
+          // TODO: add assert for that?
+        }
+
+      } else {
+        auto ret = lastTier ? true : candidate->markForEvictionWhenMoving();
+        XDCHECK(ret);
+      }
 
       unlinkItemForEviction(*candidate);
       
@@ -1761,7 +1739,6 @@ CacheAllocator<CacheTrait>::tryEvictToNextMemoryTier(
     TierId tid, PoolId pid, Item& item, bool fromBgThread) {
   XDCHECK(item.isMoving());
   XDCHECK(item.getRefCount() == 0);
-  if(item.hasChainedItem()) return WriteHandle{}; // TODO: We do not support ChainedItem yet
   if(item.isExpired()) {
     accessContainer_->remove(item);
     item.unmarkMoving();
@@ -1771,12 +1748,7 @@ CacheAllocator<CacheTrait>::tryEvictToNextMemoryTier(
   TierId nextTier = tid; // TODO - calculate this based on some admission policy
   while (++nextTier < getNumTiers()) { // try to evict down to the next memory tiers
     // allocateInternal might trigger another eviction
-    auto newItemHdl = allocateInternalTier(nextTier, pid,
-                     item.getKey(),
-                     item.getSize(),
-                     item.getCreationTime(),
-                     item.getExpiryTime(),
-                     fromBgThread);
+    auto newItemHdl = allocateNewItemForOldItem(item, nextTier, fromBgThread);
 
     if (newItemHdl) {
       XDCHECK_EQ(newItemHdl->getSize(), item.getSize());
@@ -3066,15 +3038,8 @@ bool CacheAllocator<CacheTrait>::moveForSlabRelease(
        ++itemMovingAttempts) {
     stats_.numMoveAttempts.inc();
 
-    // Nothing to move and the key is likely also bogus for chained items.
-    if (oldItem.isOnlyMoving()) {
-      auto ret = unmarkMovingAndWakeUpWaiters(oldItem, {});
-      XDCHECK(ret == 0);
-      const auto res =
-          releaseBackToAllocator(oldItem, RemoveContext::kNormal, false);
-      XDCHECK(res == ReleaseRes::kReleased);
-      return true;
-    }
+    // Since this thread marked item as moving, no one could have removed/replace the item
+    XDCHECK(!oldItem.isOnlyMoving());
 
     throttleWith(throttler, [&] {
       XLOGF(WARN,
@@ -3085,7 +3050,7 @@ bool CacheAllocator<CacheTrait>::moveForSlabRelease(
     });
 
     if (!newItemHdl) {
-      newItemHdl = allocateNewItemForOldItem(oldItem);
+      newItemHdl = allocateNewItemForOldItem(oldItem, getTierId(oldItem), true);
     }
 
     // if we have a valid handle, try to move, if not, we retry.
@@ -3151,7 +3116,7 @@ CacheAllocator<CacheTrait>::validateAndGetParentHandleForChainedMoveLocked(
 
 template <typename CacheTrait>
 typename CacheAllocator<CacheTrait>::WriteHandle
-CacheAllocator<CacheTrait>::allocateNewItemForOldItem(const Item& oldItem) {
+CacheAllocator<CacheTrait>::allocateNewItemForOldItem(const Item& oldItem, TierId tid, bool fromBgThread) {
   XDCHECK(oldItem.isMoving());
   if (oldItem.isChainedItem()) {
     const auto& oldChainedItem = oldItem.asChainedItem();
@@ -3169,7 +3134,7 @@ CacheAllocator<CacheTrait>::allocateNewItemForOldItem(const Item& oldItem) {
     // Set up the destination for the move. Since oldChainedItem would
     // be marked as moving, it won't be picked for eviction.
     auto newItemHdl =
-        allocateChainedItemInternal(parentHandle, oldItem.getSize());
+        allocateChainedItemInternal(parentHandle, oldItem.getSize(), tid, fromBgThread);
     if (!newItemHdl) {
       return {};
     }
@@ -3184,11 +3149,11 @@ CacheAllocator<CacheTrait>::allocateNewItemForOldItem(const Item& oldItem) {
   }
 
   const auto allocInfo =
-      allocator_[getTierId(oldItem)]->getAllocInfo(static_cast<const void*>(&oldItem));
+      allocator_[tid]->getAllocInfo(static_cast<const void*>(&oldItem));
 
   // Set up the destination for the move. Since oldItem would have the moving
   // bit set, it won't be picked for eviction.
-  auto newItemHdl = allocateInternalTier(getTierId(oldItem),
+  auto newItemHdl = allocateInternalTier(tid,
                                          allocInfo.poolId,
                                          oldItem.getKey(),
                                          oldItem.getSize(),
@@ -3310,23 +3275,15 @@ void CacheAllocator<CacheTrait>::evictForSlabRelease(
                                        .toString())
                   : "");
     });
-    // if the item is already in a state where only the exclusive bit is set,
-    // nothing needs to be done. We simply need to call unmarkMoving and free
-    // the item.
-    if (item.isOnlyMoving()) {
-      auto ref = unmarkMovingAndWakeUpWaiters(item, {});
-      XDCHECK(ref == 0);
-      const auto res =
-          releaseBackToAllocator(item, RemoveContext::kNormal, false);
-      XDCHECK(ReleaseRes::kReleased == res);
-      return;
-    }
+    
+    XDCHECK(!item.isOnlyMoving());
 
     typename NvmCacheT::PutToken token;
     Item* evicted;
     if (item.isChainedItem()) {
       auto& expectedParent = item.asChainedItem().getParentItem(compressor_);
 
+     // TODO:SAFE TO REMOVE????
       if (getNumTiers() == 1) {
         // TODO: unify this with multi-tier implementation
         // right now, taking a chained item lock here would lead to deadlock
@@ -3479,6 +3436,7 @@ bool CacheAllocator<CacheTrait>::markMovingForSlabRelease(
     // Since this callback is executed, the item is not yet freed
     itemFreed = false;
     Item* item = static_cast<Item*>(memory);
+
     if (item->markMoving()) {
       markedMoving = true;
     }

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -1979,7 +1979,7 @@ auto& mmContainer = getMMContainer(tid, pid, cid);
           throw std::runtime_error("Not supported for chained items");
         }
 
-        if (candidate->markMoving(true)) {
+        if (candidate->markMoving()) {
           mmContainer.remove(itr);
           candidates.push_back(candidate);
         } else {
@@ -2052,7 +2052,7 @@ auto& mmContainer = getMMContainer(tid, pid, cid);
 
         // TODO: only allow it for read-only items?
         // or implement mvcc
-        if (candidate->markMoving(true)) {
+        if (candidate->markMoving()) {
           // promotions should rarely fail since we already marked moving
           mmContainer.remove(itr);
           candidates.push_back(candidate);

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -1542,7 +1542,7 @@ class CacheAllocator : public CacheBase {
   // @throw     std::invalid_argument if the size requested is invalid or
   //            if the item is invalid
   WriteHandle allocateChainedItemInternal(const ReadHandle& parent,
-                                          uint32_t size);
+                                          uint32_t size, TierId tid, bool fromBgThread);
 
   // Given an item and its parentKey, validate that the parentKey
   // corresponds to an item that's the parent of the supplied item.
@@ -1563,7 +1563,7 @@ class CacheAllocator : public CacheBase {
   //
   // @return  handle to the newly allocated item
   //
-  WriteHandle allocateNewItemForOldItem(const Item& item);
+  WriteHandle allocateNewItemForOldItem(const Item& item, TierId tid, bool fromBgThread);
 
   // internal helper that grabs a refcounted handle to the item. This does
   // not record the access to reflect in the mmContainer.

--- a/cachelib/allocator/CacheItem-inl.h
+++ b/cachelib/allocator/CacheItem-inl.h
@@ -238,8 +238,8 @@ bool CacheItem<CacheTrait>::markForEvictionWhenMoving() {
 }
 
 template <typename CacheTrait>
-bool CacheItem<CacheTrait>::markMoving(bool failIfRefNotZero) {
-  return ref_.markMoving(failIfRefNotZero);
+bool CacheItem<CacheTrait>::markMoving() {
+  return ref_.markMoving();
 }
 
 template <typename CacheTrait>

--- a/cachelib/allocator/CacheItem.h
+++ b/cachelib/allocator/CacheItem.h
@@ -381,7 +381,7 @@ class CACHELIB_PACKED_ATTR CacheItem {
    * Unmarking moving will also return the refcount at the moment of
    * unmarking.
    */
-  bool markMoving(bool failIfRefNotZero);
+  bool markMoving();
   RefcountWithFlags::Value unmarkMoving() noexcept;
   bool isMoving() const noexcept;
   bool isOnlyMoving() const noexcept;

--- a/cachelib/allocator/Refcount.h
+++ b/cachelib/allocator/Refcount.h
@@ -320,12 +320,18 @@ class FOLLY_PACK_ATTR RefcountWithFlags {
    *
    * Unmarking moving does not depend on `isInMMContainer`
    */
-  bool markMoving(bool failIfRefNotZero) {
-    auto predicate = [failIfRefNotZero](const Value curValue) {
+  bool markMoving() {
+    auto predicate = [](const Value curValue) {
       Value conditionBitMask = getAdminRef<kLinked>();
       const bool flagSet = curValue & conditionBitMask;
       const bool alreadyExclusive = curValue & getAdminRef<kExclusive>();
-      if (failIfRefNotZero && (curValue & kAccessRefMask) != 0) {
+      const bool isChained = curValue & getFlag<kIsChainedItem>();
+
+      // chained item can have ref count == 1, this just means it's linked in the chain
+      if (isChained && (curValue & kAccessRefMask) > 1) {
+        return false;
+      }
+      if ((curValue & kAccessRefMask) != 0) {
         return false;
       }
       if (!flagSet || alreadyExclusive) {

--- a/cachelib/cachebench/test_configs/small_moving_bg.json
+++ b/cachelib/cachebench/test_configs/small_moving_bg.json
@@ -1,0 +1,40 @@
+// @nolint like default.json, but moves items during slab release instead of evicting them.
+{
+    "cache_config" : {
+      "cacheSizeMB" : 2248,
+      "cacheDir": "/tmp/mem-tier5",
+      "memoryTiers" : [
+        {
+          "ratio": 1,
+          "memBindNodes": 0
+        }, {
+          "ratio": 1,
+          "memBindNodes": 0
+        }
+      ],
+      "poolRebalanceIntervalSec" : 1,
+      "moveOnSlabRelease" : true,
+      "rebalanceMinSlabs" : 2,
+      "evictorThreads": 2,
+      "promoterThreads": 2
+    },
+    "test_config" : 
+      {
+        "preallocateCache" : true,
+        "numOps" : 40000000,
+        "numThreads" : 32,
+        "numKeys" : 250000,
+        "generator": "online",
+  
+        "keySizeRange" : [1, 8, 32, 64, 128, 256, 512],
+        "keySizeRangeProbability" : [0.1, 0.1, 0.2, 0.2, 0.3, 0.1],
+  
+        "valSizeRange" : [1, 128, 512, 1024, 4096, 10240, 20480, 40960, 60000],
+        "valSizeRangeProbability" : [0.1, 0.1, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1],
+  
+        "getRatio" : 0.70,
+        "setRatio" : 0.30
+      }
+   
+  }
+  

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,3 +13,4 @@ fi
 
 ../bin/cachebench --json_test_config ../test_configs/consistency/navy.json
 ../bin/cachebench --json_test_config ../test_configs/consistency/navy-multi-tier.json
+../opt/bin/cachebench --json_test_config /opt/test_configs/small_moving_bg.json


### PR DESCRIPTION
This is WIP, does not compile and SlabRelease logic in untouched.

[Add child-item synchronization](https://github.com/intel/CacheLib/pull/77/commits/0d0a459ea16df0c78c88d4e0b7bb4b62fb793a2c) 

Mark child item as moving, instead of a parent.

Assumptions/description:
1. If item is marked as moving in ReleaseBackToAllocator just skip this item
	It will be discareded by the moving thread once it realises there is no parent item. (moveChainedItem verifies the parent handle and if the parent is being evicted the handle will be NULL).
2. We don't actually need to to synchronize (check isMoving) for every child item in the chain when iterating
	- forEachChainedItem / viewAsChainedAlloc will synchronize on the chainedItemLocks_ (we don't actually do anything with the moving item until we grab exlusive lock in moveChainedItem)
	- popChainedItem - will synchronize on acquire(head)
	- replaceChainedItem - will synchronize on acquire(oldItem)
	- addChainItem - no problem, synchronization on chainedItemLocks_
	- transferChainLocked - the moving item might be transferred to a new parent. That's fine, we will notice this in moveChainedItem and return false.

	Whenever head item is used in those functions, there is a handle acquired for it so it will also synchronize correctly.
3. I assume this will suffer from the same deadlock problem that @byrnedj solved by using tryLock on chaineItemLocks_.  Probably we'll need the same approach here. 

@byrnedj Regarding 3 (this might apply to your approach as well): Perhaps we could solve the deadlock by just using the same chainedItemLocks_ that is used to synchronize modifications to the chain? I mean, when creating a wait context for a child item,  why not just use `chainedItemLocks_[child.getParent().getKey()]`? (if this is possible to implement) 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/CacheLib/77)
<!-- Reviewable:end -->
