### PR TITLE
Improvements to the background workers

### DIFF
--- a/cachelib/CMakeLists.txt
+++ b/cachelib/CMakeLists.txt
@@ -43,6 +43,7 @@ set(PACKAGE_BUGREPORT "https://github.com/facebook/TBD")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_TESTS "If enabled, compile the tests." ON)
+option(BUILD_WITH_DTO "If enabled, build with DSA transparent offloading." OFF)
 
 
 set(BIN_INSTALL_DIR bin CACHE STRING

--- a/cachelib/allocator/BackgroundMover-inl.h
+++ b/cachelib/allocator/BackgroundMover-inl.h
@@ -25,10 +25,23 @@ BackgroundMover<CacheT>::BackgroundMover(
     : cache_(cache), strategy_(strategy), direction_(direction) {
   if (direction_ == MoverDir::Evict) {
     moverFunc = BackgroundMoverAPIWrapper<CacheT>::traverseAndEvictItems;
-
   } else if (direction_ == MoverDir::Promote) {
     moverFunc = BackgroundMoverAPIWrapper<CacheT>::traverseAndPromoteItems;
   }
+}
+
+template <typename CacheT>
+void BackgroundMover<CacheT>::TraversalStats::recordTraversalTime(uint64_t nsTaken) {
+  lastTraversalTimeNs_ = nsTaken;
+  minTraversalTimeNs_ = std::min(minTraversalTimeNs_, nsTaken);
+  maxTraversalTimeNs_ = std::max(maxTraversalTimeNs_, nsTaken);
+  totalTraversalTimeNs_ += nsTaken;
+}
+
+template <typename CacheT>
+uint64_t BackgroundMover<CacheT>::TraversalStats::getAvgTraversalTimeNs(
+    uint64_t numTraversals) const {
+  return numTraversals ? totalTraversalTimeNs_ / numTraversals : 0;
 }
 
 template <typename CacheT>
@@ -64,46 +77,54 @@ template <typename CacheT>
 void BackgroundMover<CacheT>::checkAndRun() {
   auto assignedMemory = mutex_.lock_combine([this] { return assignedMemory_; });
 
-  unsigned int moves = 0;
-  std::set<ClassId> classes{};
-  auto batches = strategy_->calculateBatchSizes(cache_, assignedMemory);
+  while (true) {
+    unsigned int moves = 0;
+    std::set<ClassId> classes{};
+    auto batches = strategy_->calculateBatchSizes(cache_, assignedMemory);
 
-  for (size_t i = 0; i < batches.size(); i++) {
-    const auto [tid, pid, cid] = assignedMemory[i];
-    const auto batch = batches[i];
+    const auto begin = util::getCurrentTimeNs();
+    for (size_t i = 0; i < batches.size(); i++) {
+      const auto [tid, pid, cid] = assignedMemory[i];
+      const auto batch = batches[i];
+      if (!batch) {
+        continue;
+      }
 
-    if (batch == 0) {
-      continue;
+      // try moving BATCH items from the class in order to reach free target
+      auto moved = moverFunc(cache_, tid, pid, cid, batch);
+      moves += moved;
+      moves_per_class_[assignedMemory[i]] += moved;
     }
-    classes.insert(cid);
-    const auto& mpStats = cache_.getPoolByTid(pid, tid).getStats();
-    // try moving BATCH items from the class in order to reach free target
-    auto moved = moverFunc(cache_, tid, pid, cid, batch);
-    moves += moved;
-    moves_per_class_[tid][pid][cid] += moved;
-    totalBytesMoved_.add(moved * mpStats.acStats.at(cid).allocSize );
-  }
+    auto end = util::getCurrentTimeNs();
+    if (moves > 0) {
+      traversalStats_.recordTraversalTime(end > begin ? end - begin : 0);
+      numMovedItems += moves;
+      numTraversals++;
+    }
 
-  numTraversals_.inc();
-  numMovedItems_.add(moves);
-  totalClasses_.add(classes.size());
+    //we didn't move any objects done with this run
+    if (moves == 0 || shouldStopWork()) {
+        break;
+    }
+  }
 }
 
 template <typename CacheT>
 BackgroundMoverStats BackgroundMover<CacheT>::getStats() const noexcept {
   BackgroundMoverStats stats;
-  stats.numMovedItems = numMovedItems_.get();
-  stats.runCount = numTraversals_.get();
-  stats.totalBytesMoved = totalBytesMoved_.get();
-  stats.totalClasses = totalClasses_.get();
+  stats.numMovedItems = numMovedItems;
+  stats.totalBytesMoved = totalBytesMoved;
+  stats.totalClasses = totalClasses;
+  auto runCount = getRunCount();
+  stats.runCount = runCount;
+  stats.numTraversals = numTraversals;
+  stats.avgItemsMoved = (double) stats.numMovedItems / (double)runCount;
+  stats.lastTraversalTimeNs = traversalStats_.getLastTraversalTimeNs();
+  stats.avgTraversalTimeNs = traversalStats_.getAvgTraversalTimeNs(numTraversals);
+  stats.minTraversalTimeNs = traversalStats_.getMinTraversalTimeNs();
+  stats.maxTraversalTimeNs = traversalStats_.getMaxTraversalTimeNs();
 
   return stats;
-}
-
-template <typename CacheT>
-std::map<TierId, std::map<PoolId, std::map<ClassId, uint64_t>>>
-BackgroundMover<CacheT>::getClassStats() const noexcept {
-  return moves_per_class_;
 }
 
 template <typename CacheT>

--- a/cachelib/allocator/BackgroundMoverStrategy.h
+++ b/cachelib/allocator/BackgroundMoverStrategy.h
@@ -38,5 +38,34 @@ class BackgroundMoverStrategy {
   virtual ~BackgroundMoverStrategy() = default;
 };
 
+class DefaultBackgroundMoverStrategy : public BackgroundMoverStrategy {
+  public:
+    DefaultBackgroundMoverStrategy(uint64_t batchSize, double targetFree)
+      : batchSize_(batchSize), targetFree_((double)targetFree/100.0) {}
+    ~DefaultBackgroundMoverStrategy() {}
+
+  std::vector<size_t> calculateBatchSizes(
+      const CacheBase& cache,
+      std::vector<MemoryDescriptorType> acVec) {
+    std::vector<size_t> batches{};
+    for (auto [tid, pid, cid] : acVec) {
+        double usage = cache.getPoolByTid(pid, tid).getApproxUsage(cid);
+        uint32_t perSlab = cache.getPoolByTid(pid, tid).getPerSlab(cid);
+        if (usage >= (1.0-targetFree_)) {
+          uint32_t batch = batchSize_ > perSlab ? perSlab : batchSize_;
+          batches.push_back(batch);
+        } else {
+          //no work to be done since there is already
+          //at least targetFree remaining in the class
+          batches.push_back(0);
+        }
+    }
+    return batches;
+  }
+  private:
+    uint64_t batchSize_{100};
+    double targetFree_{0.05};
+};
+
 } // namespace cachelib
 } // namespace facebook

--- a/cachelib/allocator/BackgroundMoverStrategy.h
+++ b/cachelib/allocator/BackgroundMoverStrategy.h
@@ -21,14 +21,6 @@
 namespace facebook {
 namespace cachelib {
 
-struct MemoryDescriptorType {
-  MemoryDescriptorType(TierId tid, PoolId pid, ClassId cid) : 
-      tid_(tid), pid_(pid), cid_(cid) {}
-  TierId tid_;
-  PoolId pid_;
-  ClassId cid_;
-};
-
 // Base class for background eviction strategy.
 class BackgroundMoverStrategy {
  public:

--- a/cachelib/allocator/Cache.h
+++ b/cachelib/allocator/Cache.h
@@ -73,6 +73,22 @@ enum class DestructorContext {
   kRemovedFromNVM
 };
 
+struct MemoryDescriptorType {
+    MemoryDescriptorType(TierId tid, PoolId pid, ClassId cid) :
+        tid_(tid), pid_(pid), cid_(cid) {}
+    TierId tid_;
+    PoolId pid_;
+    ClassId cid_;
+
+    bool operator<(const MemoryDescriptorType& rhs) const {
+      return std::make_tuple(tid_, pid_, cid_) < std::make_tuple(rhs.tid_, rhs.pid_, rhs.cid_);
+    }
+
+    bool operator==(const MemoryDescriptorType& rhs) const {
+      return std::make_tuple(tid_, pid_, cid_) == std::make_tuple(rhs.tid_, rhs.pid_, rhs.cid_);
+    }
+};
+
 // A base class of cache exposing members and status agnostic of template type.
 class CacheBase {
  public:

--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -2893,6 +2893,9 @@ ACStats CacheAllocator<CacheTrait>::getACStats(TierId tid,
 
   auto stats = ac.getStats();
   stats.allocLatencyNs = (*stats_.classAllocLatency)[tid][poolId][classId];
+  stats.evictionAttempts = (*stats_.evictionAttempts)[tid][poolId][classId].get();
+  stats.evictions = (*stats_.regularItemEvictions)[tid][poolId][classId].get() + 
+                    (*stats_.chainedItemEvictions)[tid][poolId][classId].get();
   return stats;
 }
 

--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -401,9 +401,13 @@ CacheAllocator<CacheTrait>::allocate(PoolId poolId,
 }
 
 template <typename CacheTrait>
-bool CacheAllocator<CacheTrait>::shouldWakeupBgEvictor(TierId tid,
-                                                       PoolId /* pid */,
-                                                       ClassId /* cid */) {
+bool CacheAllocator<CacheTrait>::shouldWakeupBgEvictor(TierId tid, PoolId pid, ClassId cid) {
+  // TODO: should we also work on lower tiers? should we have separate set of params?
+  if (tid == 1) return false;
+  double usage = getPoolByTid(pid, tid).getApproxUsage(cid);
+  if (((1-usage)*100) <= config_.lowEvictionAcWatermark) {
+    return true;
+  }
   return false;
 }
 

--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -412,6 +412,37 @@ bool CacheAllocator<CacheTrait>::shouldWakeupBgEvictor(TierId tid, PoolId pid, C
 }
 
 template <typename CacheTrait>
+std::vector<void*> CacheAllocator<CacheTrait>::allocateInternalTierByCidBatch(TierId tid,
+                                                 PoolId pid,
+                                                 ClassId cid, uint64_t batch) {
+  util::LatencyTracker tracker{stats().allocateLatency_};
+
+  SCOPE_FAIL { stats_.invalidAllocs.add(batch); };
+
+  util::RollingLatencyTracker rollTracker{
+      (*stats_.classAllocLatency)[tid][pid][cid]};
+
+  (*stats_.allocAttempts)[tid][pid][cid].add(batch);
+  
+  auto memory = allocator_[tid]->allocateByCidBatch(pid, cid, batch);
+  
+  if (memory.size() < batch) {
+    uint64_t toEvict = batch - memory.size();
+    auto evicted = findEvictionBatch(tid, pid, cid, toEvict);
+    if (evicted.size() < toEvict) {
+      (*stats_.allocFailures)[tid][pid][cid].add(toEvict - evicted.size());
+    }
+    if (evicted.size() > 0) {
+      //case where we some allocations from eviction - add them to
+      //the new allocations
+      memory.insert(memory.end(),evicted.begin(),evicted.end());
+      return memory;
+    }
+  }
+  return memory;
+}
+
+template <typename CacheTrait>
 typename CacheAllocator<CacheTrait>::WriteHandle
 CacheAllocator<CacheTrait>::allocateInternalTier(TierId tid,
                                                  PoolId pid,
@@ -419,9 +450,8 @@ CacheAllocator<CacheTrait>::allocateInternalTier(TierId tid,
                                                  uint32_t size,
                                                  uint32_t creationTime,
                                                  uint32_t expiryTime,
-                                                 bool fromBgThread,
                                                  bool evict) {
-  util::LatencyTracker tracker{stats().allocateLatency_, static_cast<size_t>(!fromBgThread)};
+  util::LatencyTracker tracker{stats().allocateLatency_};
   SCOPE_FAIL { stats_.invalidAllocs.inc(); };
 
   // number of bytes required for this item
@@ -436,7 +466,7 @@ CacheAllocator<CacheTrait>::allocateInternalTier(TierId tid,
   
   void* memory = allocator_[tid]->allocate(pid, requiredSize);
 
-  if (backgroundEvictor_.size() && !fromBgThread &&
+  if (backgroundEvictor_.size() &&
       (memory == nullptr || shouldWakeupBgEvictor(tid, pid, cid))) {
     backgroundEvictor_[BackgroundMover<CacheT>::workerId(
                            tid, pid, cid, backgroundEvictor_.size())]
@@ -492,12 +522,11 @@ CacheAllocator<CacheTrait>::allocateInternal(PoolId pid,
                                              typename Item::Key key,
                                              uint32_t size,
                                              uint32_t creationTime,
-                                             uint32_t expiryTime,
-                                             bool fromBgThread) {
+                                             uint32_t expiryTime) {
   auto tid = 0; /* TODO: consult admission policy */
   for(TierId tid = 0; tid < getNumTiers(); ++tid) {
     bool evict = !config_.insertToFirstFreeTier || tid == getNumTiers() - 1;
-    auto handle = allocateInternalTier(tid, pid, key, size, creationTime, expiryTime, fromBgThread, evict);
+    auto handle = allocateInternalTier(tid, pid, key, size, creationTime, expiryTime, evict);
     if (handle) return handle;
   }
   return {};
@@ -1318,9 +1347,8 @@ void CacheAllocator<CacheTrait>::wakeUpWaiters(folly::StringPiece key,
 }
 
 template <typename CacheTrait>
-bool CacheAllocator<CacheTrait>::moveRegularItem(Item& oldItem,
-                                                 WriteHandle& newItemHdl) {
-  XDCHECK(oldItem.isMoving());
+bool CacheAllocator<CacheTrait>::moveRegularItem(
+    Item& oldItem, WriteHandle& newItemHdl, bool skipAddInMMContainer, bool fromBgThread) {
   XDCHECK(!oldItem.isExpired());
   util::LatencyTracker tracker{stats_.moveRegularLatency_};
 
@@ -1343,15 +1371,21 @@ bool CacheAllocator<CacheTrait>::moveRegularItem(Item& oldItem,
     // should be fine for it to be left in an inconsistent state.
     config_.moveCb(oldItem, *newItemHdl, nullptr);
   } else {
-    std::memcpy(newItemHdl->getMemory(), oldItem.getMemory(),
+    if (fromBgThread) {
+      std::memmove(newItemHdl->getMemory(), oldItem.getMemory(),
                 oldItem.getSize());
+    } else {
+      std::memcpy(newItemHdl->getMemory(), oldItem.getMemory(),
+                oldItem.getSize());
+    }
   }
 
-  // Adding the item to mmContainer has to succeed since no one can remove the
-  // item
-  auto& newContainer = getMMContainer(*newItemHdl);
-  auto mmContainerAdded = newContainer.add(*newItemHdl);
-  XDCHECK(mmContainerAdded);
+  if (!skipAddInMMContainer) {
+    // Adding the item to mmContainer has to succeed since no one can remove the item
+    auto& newContainer = getMMContainer(*newItemHdl);
+    auto mmContainerAdded = newContainer.add(*newItemHdl);
+    XDCHECK(mmContainerAdded);
+  }
 
   if (oldItem.hasChainedItem()) {
     XDCHECK(!newItemHdl->hasChainedItem()) << newItemHdl->toString();
@@ -1367,12 +1401,17 @@ bool CacheAllocator<CacheTrait>::moveRegularItem(Item& oldItem,
     XDCHECK(!oldItem.hasChainedItem());
     XDCHECK(newItemHdl->hasChainedItem());
   }
+  
+  auto predicate = [&](const Item& item){
+    // we rely on moving flag being set (it should block all readers)
+    return true;
+  };
 
   if (!accessContainer_->replaceIfAccessible(oldItem, *newItemHdl)) {
+    auto& newContainer = getMMContainer(*newItemHdl);
     newContainer.remove(*newItemHdl);
     return false;
   }
-
   newItemHdl.unmarkNascent();
   return true;
 }
@@ -1438,6 +1477,472 @@ void CacheAllocator<CacheTrait>::unlinkItemForEviction(Item& it) {
   // owner of the item.
   const auto ref = it.unmarkForEviction();
   XDCHECK_EQ(0u, ref);
+}
+
+template <typename CacheTrait>
+std::vector<typename CacheAllocator<CacheTrait>::Item*>
+CacheAllocator<CacheTrait>::findEvictionBatch(TierId tid,
+                                             PoolId pid,
+                                             ClassId cid,
+                                             unsigned int batch) {
+
+  std::vector<Item*> toRecycles;
+  toRecycles.reserve(batch);
+  auto evictionData = getNextCandidates(tid,pid,cid,batch,true,false);
+  for (int i = 0; i < evictionData.size(); i++) {
+    Item *candidate = evictionData[i].candidate;
+    Item *toRecycle = evictionData[i].toRecycle;
+    toRecycles.push_back(toRecycle);
+    // recycle the item. it's safe to do so, even if toReleaseHandle was
+    // NULL. If `ref` == 0 then it means that we are the last holder of
+    // that item.
+    if (candidate->hasChainedItem()) {
+      (*stats_.chainedItemEvictions)[tid][pid][cid].inc();
+    } else {
+      (*stats_.regularItemEvictions)[tid][pid][cid].inc();
+    }
+
+    if (auto eventTracker = getEventTracker()) {
+      eventTracker->record(AllocatorApiEvent::DRAM_EVICT, candidate->getKey(),
+                           AllocatorApiResult::EVICTED, candidate->getSize(),
+                           candidate->getConfiguredTTL().count());
+    }
+
+    XDCHECK(!candidate->isChainedItem());
+    // check if by releasing the item we intend to, we actually
+    // recycle the candidate.
+    auto ret = releaseBackToAllocator(*candidate, RemoveContext::kEviction,
+                                      /* isNascent */ false, toRecycle);
+    XDCHECK_EQ(ret,ReleaseRes::kRecycled);
+  }
+  return toRecycles;
+}
+
+template <typename CacheTrait>
+std::vector<typename CacheAllocator<CacheTrait>::Item*>
+CacheAllocator<CacheTrait>::getNextCandidatesPromotion(TierId tid,
+                                             PoolId pid,
+                                             ClassId cid,
+                                             unsigned int batch,
+                                             bool markMoving,
+                                             bool fromBgThread) {
+  std::vector<Item*> newAllocs;
+  std::vector<void*> blankAllocs;
+  std::vector<WriteHandle> newHandles;
+  std::vector<WriteHandle> candidateHandles;
+  std::vector<Item*> candidates;
+  candidates.reserve(batch);
+  candidateHandles.reserve(batch);
+  newAllocs.reserve(batch);
+  newHandles.reserve(batch);
+
+  auto& mmContainer = getMMContainer(tid, pid, cid);
+  unsigned int maxSearchTries = std::max(config_.evictionSearchTries,
+                                            batch*4);
+
+  // first try and get allocations in the next tier
+  blankAllocs = allocateInternalTierByCidBatch(tid-1,pid,cid,batch);
+  if (blankAllocs.empty()) {
+    return candidates;  
+  } else if (blankAllocs.size() < batch) {
+    batch = blankAllocs.size();
+  }
+  XDCHECK_EQ(blankAllocs.size(),batch);
+
+  auto iterateAndMark = [this, tid, pid, cid, batch,
+                         markMoving, maxSearchTries,
+                         &candidates, &candidateHandles,
+                         &mmContainer](auto&& itr) {
+
+    unsigned int searchTries = 0;
+    if (!itr) {
+      ++searchTries;
+      return;
+    }
+
+    while ((config_.evictionSearchTries == 0 ||
+            maxSearchTries > searchTries) &&
+           itr && candidates.size() < batch) {
+      ++searchTries;
+      auto* toRecycle_ = itr.get();
+      bool chainedItem_ = toRecycle_->isChainedItem();
+
+      if (chainedItem_) {
+          ++itr;
+          continue;
+      }
+      Item* candidate_;
+      WriteHandle candidateHandle_;
+      Item* syncItem_;
+      //sync on the parent item for chained items to move to next tier
+      candidate_ = toRecycle_;
+      syncItem_ = toRecycle_;
+      
+      bool marked = false;
+      if (markMoving) {
+        marked = syncItem_->markMoving();
+      } else if (!markMoving) {
+        //we use item handle as sync point - for background eviction
+        auto hdl = acquire(candidate_);
+        if (hdl && hdl->getRefCount() == 1) {
+          marked = true;
+          candidateHandle_ = std::move(hdl);
+        }
+      }
+      if (!marked) {
+        ++itr;
+        continue;
+      }
+      XDCHECK(!chainedItem_); 
+      mmContainer.remove(itr);
+      candidates.push_back(candidate_);
+      candidateHandles.push_back(std::move(candidateHandle_));
+    }
+  };
+  
+  mmContainer.withPromotionIterator(iterateAndMark);
+
+  if (candidates.size() < batch) {
+    unsigned int toErase = batch - candidates.size();
+    for (int i = 0; i < toErase; i++) {
+      allocator_[tid-1]->free(blankAllocs.back());
+      blankAllocs.pop_back();
+    }
+    if (candidates.size() == 0) {
+      return candidates;  
+    }
+  }
+  
+  //1. get and item handle from a new allocation
+  for (int i = 0; i < candidates.size(); i++) {
+    Item *candidate = candidates[i];
+    WriteHandle newItemHdl = acquire(new (blankAllocs[i]) 
+            Item(candidate->getKey(), candidate->getSize(),
+                 candidate->getCreationTime(), candidate->getExpiryTime()));
+    XDCHECK(newItemHdl);
+    if (newItemHdl) {
+      newItemHdl.markNascent();
+      (*stats_.fragmentationSize)[tid][pid][cid].add(
+          util::getFragmentation(*this, *newItemHdl));
+      newAllocs.push_back(newItemHdl.getInternal());
+      newHandles.push_back(std::move(newItemHdl));
+    } else {
+      //failed to get item handle
+      throw std::runtime_error(
+         folly::sformat("Was not to acquire new alloc, failed alloc {}", blankAllocs[i]));
+    }
+  }
+  //2. add in batch to mmContainer
+  auto& newMMContainer = getMMContainer(tid-1, pid, cid);
+  uint32_t added = newMMContainer.addBatch(newAllocs.begin(), newAllocs.end());
+  XDCHECK_EQ(added,newAllocs.size());
+  if (added != newAllocs.size()) {
+    throw std::runtime_error(
+      folly::sformat("Was not able to add all new items, failed item {} and handle {}", 
+                      newAllocs[added]->toString(),newHandles[added]->toString()));
+  }
+  //3. copy item data - don't need to add in mmContainer
+  for (int i = 0; i < candidates.size(); i++) {
+    Item *candidate = candidates[i];
+    WriteHandle newHandle = std::move(newHandles[i]);
+    bool moved = moveRegularItem(*candidate,newHandle, true, true);
+    if (moved) {
+      XDCHECK(candidate->getKey() == newHandle->getKey());
+      if (markMoving) {
+        auto ref = candidate->unmarkMoving();
+        XDCHECK_EQ(ref,0);
+        wakeUpWaiters(candidate->getKey(), std::move(newHandle));
+        const auto res =
+            releaseBackToAllocator(*candidate, RemoveContext::kNormal, false);
+        XDCHECK(res == ReleaseRes::kReleased);
+      }
+    } else {
+      typename NvmCacheT::PutToken token{};
+      
+      removeFromMMContainer(*newAllocs[i]);
+      auto ret = handleFailedMove(candidate,token,false,markMoving);
+      XDCHECK(ret);
+      if (markMoving && candidate->getRefCountAndFlagsRaw() == 0) {
+        const auto res =
+            releaseBackToAllocator(*candidate, RemoveContext::kNormal, false);
+        XDCHECK(res == ReleaseRes::kReleased);
+      }
+
+    }
+  }
+  return candidates;
+}
+
+template <typename CacheTrait>
+std::vector<typename CacheAllocator<CacheTrait>::EvictionData>
+CacheAllocator<CacheTrait>::getNextCandidates(TierId tid,
+                                             PoolId pid,
+                                             ClassId cid,
+                                             unsigned int batch,
+                                             bool markMoving,
+                                             bool fromBgThread) {
+
+  std::vector<void*> blankAllocs;
+  std::vector<Item*> newAllocs;
+  std::vector<WriteHandle> newHandles;
+  std::vector<EvictionData> evictionData;
+  evictionData.reserve(batch);
+  newAllocs.reserve(batch);
+  newHandles.reserve(batch);
+  
+  auto& mmContainer = getMMContainer(tid, pid, cid);
+  bool lastTier = tid+1 >= getNumTiers();
+  unsigned int maxSearchTries = std::max(config_.evictionSearchTries,
+                                            batch*4);
+  if (!lastTier) {
+    blankAllocs = allocateInternalTierByCidBatch(tid+1,pid,cid,batch);
+    if (blankAllocs.empty()) {
+      return evictionData;  
+    } else if (blankAllocs.size() != batch) {
+      batch = blankAllocs.size(); 
+    }
+    XDCHECK_EQ(blankAllocs.size(),batch);
+  }
+
+  auto iterateAndMark = [this, tid, pid, cid, batch,
+                         markMoving, lastTier, maxSearchTries,
+                         &evictionData, &mmContainer](auto&& itr) {
+    unsigned int searchTries = 0;
+    if (!itr) {
+      ++searchTries;
+      (*stats_.evictionAttempts)[tid][pid][cid].inc();
+      return;
+    }
+
+    while ((config_.evictionSearchTries == 0 ||
+            maxSearchTries > searchTries) &&
+           itr && evictionData.size() < batch) {
+      ++searchTries;
+      (*stats_.evictionAttempts)[tid][pid][cid].inc();
+
+      auto* toRecycle_ = itr.get();
+      bool chainedItem_ = toRecycle_->isChainedItem();
+      Item* toRecycleParent_ = chainedItem_
+              ? &toRecycle_->asChainedItem().getParentItem(compressor_)
+              : nullptr;
+      if (toRecycle_->isExpired()) {
+          ++itr;
+          continue;
+      }
+      // in order to safely check if the expected parent (toRecycleParent_) matches
+      // the current parent on the chained item, we need to take the chained
+      // item lock so we are sure that nobody else will be editing the chain
+      auto l_ = chainedItem_
+                ? chainedItemLocks_.tryLockExclusive(toRecycleParent_->getKey())
+                : decltype(chainedItemLocks_.tryLockExclusive(toRecycle_->getKey()))();
+
+      if (chainedItem_ &&
+          ( !l_ || &toRecycle_->asChainedItem().getParentItem(compressor_)
+                    != toRecycleParent_) ) {
+          ++itr;
+          continue;
+      }
+      Item* candidate_;
+      WriteHandle candidateHandle_;
+      Item* syncItem_;
+      //sync on the parent item for chained items to move to next tier
+      if (!lastTier && chainedItem_) {
+          syncItem_ = toRecycleParent_;
+          candidate_ = toRecycle_;
+      } else if (lastTier && chainedItem_) {
+          candidate_ = toRecycleParent_;
+          syncItem_ = toRecycleParent_;
+      } else {
+          candidate_ = toRecycle_;
+          syncItem_ = toRecycle_;
+      }
+      // if it's last tier, the item will be evicted
+      // need to create put token before marking it exclusive
+      const bool evictToNvmCache = lastTier && shouldWriteToNvmCache(*candidate_);
+
+      auto token_ = evictToNvmCache
+                        ? nvmCache_->createPutToken(candidate_->getKey())
+                        : typename NvmCacheT::PutToken{};
+      
+      if (evictToNvmCache && !token_.isValid()) {
+        stats_.evictFailConcurrentFill.inc();
+        ++itr;
+        continue;
+      }
+      bool marked = false;
+      //case 1: mark the item for eviction
+      if ((lastTier || candidate_->isExpired()) && markMoving) {
+        marked = syncItem_->markForEviction();
+      } else if (markMoving) {
+        marked = syncItem_->markMoving();
+      } else if (!markMoving) {
+        //we use item handle as sync point - for background eviction
+        auto hdl = acquire(candidate_);
+        if (hdl && hdl->getRefCount() == 1) {
+          marked = true;
+          candidateHandle_ = std::move(hdl);
+        }
+      }
+      if (!marked) {
+        if (candidate_->hasChainedItem()) {
+          stats_.evictFailParentAC.inc();
+        } else {
+          stats_.evictFailAC.inc();
+        }
+        ++itr;
+        continue;
+      }
+      
+      if (chainedItem_) {
+          XDCHECK(l_);
+          XDCHECK_EQ(toRecycleParent_,&toRecycle_->asChainedItem().getParentItem(compressor_));
+      }
+      mmContainer.remove(itr);
+      EvictionData ed(candidate_,toRecycle_,toRecycleParent_,chainedItem_,
+                      candidate_->isExpired(), std::move(token_), std::move(candidateHandle_));
+      evictionData.push_back(std::move(ed));
+    }
+  };
+  
+  mmContainer.withEvictionIterator(iterateAndMark);
+
+  if (evictionData.size() < batch) {
+    if (!lastTier) {
+      unsigned int toErase = batch - evictionData.size();
+      for (int i = 0; i < toErase; i++) {
+        allocator_[tid+1]->free(blankAllocs.back());
+        blankAllocs.pop_back();
+      }
+    }
+    if (evictionData.size() == 0) {
+      return evictionData;  
+    }
+  }
+  
+  if (!lastTier) {
+    //1. get and item handle from a new allocation
+    for (int i = 0; i < evictionData.size(); i++) {
+      Item *candidate = evictionData[i].candidate;
+      WriteHandle newItemHdl = acquire(new (blankAllocs[i]) 
+              Item(candidate->getKey(), candidate->getSize(),
+                   candidate->getCreationTime(), candidate->getExpiryTime()));
+      XDCHECK(newItemHdl);
+      if (newItemHdl) {
+        newItemHdl.markNascent();
+        (*stats_.fragmentationSize)[tid][pid][cid].add(
+            util::getFragmentation(*this, *newItemHdl));
+        newAllocs.push_back(newItemHdl.getInternal());
+        newHandles.push_back(std::move(newItemHdl));
+      } else {
+        //failed to get item handle
+        throw std::runtime_error(
+           folly::sformat("Was not to acquire new alloc, failed alloc {}", blankAllocs[i]));
+      }
+    }
+    //2. add in batch to mmContainer
+    auto& newMMContainer = getMMContainer(tid+1, pid, cid);
+    uint32_t added = newMMContainer.addBatch(newAllocs.begin(), newAllocs.end());
+    XDCHECK_EQ(added,newAllocs.size());
+    if (added != newAllocs.size()) {
+      throw std::runtime_error(
+        folly::sformat("Was not able to add all new items, failed item {} and handle {}", 
+                        newAllocs[added]->toString(),newHandles[added]->toString()));
+    }
+    //3. copy item data - don't need to add in mmContainer
+    for (int i = 0; i < evictionData.size(); i++) {
+      Item *candidate = evictionData[i].candidate;
+      WriteHandle newHandle = std::move(newHandles[i]);
+      bool moved = moveRegularItem(*candidate,newHandle, true, true);
+      if (moved) {
+        (*stats_.numWritebacks)[tid][pid][cid].inc();
+        XDCHECK(candidate->getKey() == newHandle->getKey());
+        if (markMoving) {
+          auto ref = candidate->unmarkMoving();
+          XDCHECK_EQ(ref,0);
+          wakeUpWaiters(candidate->getKey(), std::move(newHandle));
+          if (fromBgThread) {
+            const auto res =
+                releaseBackToAllocator(*candidate, RemoveContext::kNormal, false);
+            XDCHECK(res == ReleaseRes::kReleased);
+          }
+        }
+      } else {
+        typename NvmCacheT::PutToken token = std::move(evictionData[i].token);
+        removeFromMMContainer(*newAllocs[i]);
+        auto ret = handleFailedMove(candidate,token,evictionData[i].expired,markMoving);
+        XDCHECK(ret);
+        if (fromBgThread && markMoving) {
+          const auto res =
+              releaseBackToAllocator(*candidate, RemoveContext::kNormal, false);
+          XDCHECK(res == ReleaseRes::kReleased);
+        }
+
+      }
+    }
+  } else {
+    //we are the last tier - just remove
+    for (int i = 0; i < evictionData.size(); i++) {
+      Item *candidate = evictionData[i].candidate;
+      typename NvmCacheT::PutToken token = std::move(evictionData[i].token);
+      auto ret = handleFailedMove(candidate,token,evictionData[i].expired,markMoving);
+      if (fromBgThread && markMoving) {
+        const auto res =
+            releaseBackToAllocator(*candidate, RemoveContext::kNormal, false);
+        XDCHECK(res == ReleaseRes::kReleased);
+      }
+    }
+  }
+
+  return evictionData;
+}
+
+// 
+// Common function in case move among tiers fails during eviction
+//
+// if insertOrReplace was called during move
+// then candidate will not be accessible (failed replace during tryEvict)
+//  - therefore this was why we failed to
+//    evict to the next tier and insertOrReplace
+//    will remove from NVM cache
+// however, if candidate is accessible
+// that means the allocation in the next
+// tier failed - so we will continue to
+// evict the item to NVM cache
+template <typename CacheTrait>
+bool CacheAllocator<CacheTrait>::handleFailedMove(Item* candidate, 
+                                                  typename NvmCacheT::PutToken& token, 
+                                                  bool isExpired,
+                                                  bool markMoving) {
+  bool failedToReplace = !candidate->isAccessible();
+  if (!token.isValid() && !failedToReplace) {
+    token = createPutToken(*candidate);
+  }
+  // in case that we are on the last tier, we whould have already marked
+  // as exclusive since we will not be moving the item to the next tier
+  // but rather just evicting all together, no need to
+  // markForEvictionWhenMoving
+  if (markMoving) {
+    if (!candidate->isMarkedForEviction() &&
+        candidate->isMoving()) {
+      auto ret = (isExpired) ? true : candidate->markForEvictionWhenMoving();
+      XDCHECK(ret);
+    }
+    unlinkItemForEviction(*candidate);
+  } else if (candidate->isAccessible()) {
+    accessContainer_->remove(*candidate);
+  }
+ 
+  if (token.isValid() && shouldWriteToNvmCacheExclusive(*candidate)
+          && !failedToReplace) {
+    nvmCache_->put(*candidate, std::move(token));
+  }
+  // wake up any readers that wait for the move to complete
+  // it's safe to do now, as we have the item marked exclusive and
+  // no other reader can be added to the waiters list
+  if (markMoving) {
+    wakeUpWaiters(candidate->getKey(), {});
+  }
+  return true;
 }
 
 template <typename CacheTrait>
@@ -1561,7 +2066,7 @@ CacheAllocator<CacheTrait>::getNextCandidate(TierId tid,
   XDCHECK(candidate);
 
   auto evictedToNext = (lastTier || isExpired) ? nullptr
-      : tryEvictToNextMemoryTier(*candidate, false);
+      : tryEvictToNextMemoryTier(*candidate);
   if (!evictedToNext) {
     //failed to move a chained item - so evict the entire chain
     if (candidate->isChainedItem()) {
@@ -1571,43 +2076,9 @@ CacheAllocator<CacheTrait>::getNextCandidate(TierId tid,
       candidate = toRecycleParent; //but now we evict the chain and in
                                     //doing so recycle the child
     }
-    //if insertOrReplace was called during move
-    //then candidate will not be accessible (failed replace during tryEvict)
-    // - therefore this was why we failed to
-    //   evict to the next tier and insertOrReplace
-    //   will remove from NVM cache
-    //however, if candidate is accessible
-    //that means the allocation in the next
-    //tier failed - so we will continue to
-    //evict the item to NVM cache
-    bool failedToReplace = !candidate->isAccessible();
-    if (!token.isValid() && !failedToReplace) {
-      token = createPutToken(*candidate);
-    }
-    // tryEvictToNextMemoryTier can fail if:
-    //    a) allocation of the new item fails in that case,
-    //       it should be still possible to mark item for eviction.
-    //    b) another thread calls insertOrReplace and the item
-    //       is no longer accessible
-    //
-    // in case that we are on the last tier, we whould have already marked
-    // as exclusive since we will not be moving the item to the next tier
-    // but rather just evicting all together, no need to
-    // markForEvictionWhenMoving
-    auto ret = (lastTier || isExpired) ? true : candidate->markForEvictionWhenMoving();
+    //clean up and evict the candidate since we failed
+    auto ret = handleFailedMove(candidate,token,isExpired,true);
     XDCHECK(ret);
-
-    unlinkItemForEviction(*candidate);
-    
-    if (token.isValid() && shouldWriteToNvmCacheExclusive(*candidate)
-            && !failedToReplace) {
-      nvmCache_->put(*candidate, std::move(token));
-    }
-    // wake up any readers that wait for the move to complete
-    // it's safe to do now, as we have the item marked exclusive and
-    // no other reader can be added to the waiters list
-    wakeUpWaiters(candidate->getKey(), {});
-
   } else {
     XDCHECK(!evictedToNext->isMarkedForEviction() && !evictedToNext->isMoving());
     XDCHECK(!candidate->isMarkedForEviction() && !candidate->isMoving());
@@ -1742,7 +2213,7 @@ bool CacheAllocator<CacheTrait>::shouldWriteToNvmCacheExclusive(
 template <typename CacheTrait>
 typename CacheAllocator<CacheTrait>::WriteHandle
 CacheAllocator<CacheTrait>::tryEvictToNextMemoryTier(
-    TierId tid, PoolId pid, Item& item, bool fromBgThread) {
+    TierId tid, PoolId pid, Item& item) {
 
   TierId nextTier = tid; // TODO - calculate this based on some admission policy
   while (++nextTier < getNumTiers()) { // try to evict down to the next memory tiers
@@ -1771,15 +2242,16 @@ CacheAllocator<CacheTrait>::tryEvictToNextMemoryTier(
                      item.getSize(),
                      item.getCreationTime(),
                      item.getExpiryTime(),
-                     fromBgThread,
                      evict);
     }
 
     if (newItemHdl) {
       bool moveSuccess = chainedItem
                       ? moveChainedItem(item.asChainedItem(), newItemHdl)
-                      : moveRegularItem(item, newItemHdl);
+                      : moveRegularItem(item, newItemHdl, 
+                      /* skipAddInMMContainer */ false, /* fromBgThread*/ false);
       if (!moveSuccess) {
+        XDCHECK(!newItemHdl->isInMMContainer());
         return WriteHandle{};
       }
       XDCHECK_EQ(newItemHdl->getSize(), item.getSize());
@@ -1798,55 +2270,10 @@ CacheAllocator<CacheTrait>::tryEvictToNextMemoryTier(
 
 template <typename CacheTrait>
 typename CacheAllocator<CacheTrait>::WriteHandle
-CacheAllocator<CacheTrait>::tryEvictToNextMemoryTier(Item& item, bool fromBgThread) {
+CacheAllocator<CacheTrait>::tryEvictToNextMemoryTier(Item& item) {
   auto tid = getTierId(item);
   auto pid = allocator_[tid]->getAllocInfo(item.getMemory()).poolId;
-  return tryEvictToNextMemoryTier(tid, pid, item, fromBgThread);
-}
-
-template <typename CacheTrait>
-typename CacheAllocator<CacheTrait>::WriteHandle
-CacheAllocator<CacheTrait>::tryPromoteToNextMemoryTier(
-    TierId tid, PoolId pid, Item& item, bool fromBgThread) {
-  if(item.isExpired()) { return {}; }
-  TierId nextTier = tid;
-  while (nextTier > 0) { // try to evict down to the next memory tiers
-    auto toPromoteTier = nextTier - 1;
-    --nextTier;
-
-    // always evict item from the toPromoteTier to make room for new item
-    bool evict = true;
-
-    // allocateInternal might trigger another eviction
-    auto newItemHdl = allocateInternalTier(toPromoteTier, pid,
-                     item.getKey(),
-                     item.getSize(),
-                     item.getCreationTime(),
-                     item.getExpiryTime(),
-                     fromBgThread,
-                     true);
-
-    if (newItemHdl) {
-      XDCHECK_EQ(newItemHdl->getSize(), item.getSize());
-      if (!moveRegularItem(item, newItemHdl)) {
-        return WriteHandle{};
-      }
-      item.unmarkMoving();
-      return newItemHdl;
-    } else {
-      return WriteHandle{};
-    }
-  }
-
-  return {};
-}
-
-template <typename CacheTrait>
-typename CacheAllocator<CacheTrait>::WriteHandle
-CacheAllocator<CacheTrait>::tryPromoteToNextMemoryTier(Item& item, bool fromBgThread) {
-    auto tid = getTierId(item);
-    auto pid = allocator_[tid]->getAllocInfo(item.getMemory()).poolId;
-    return tryPromoteToNextMemoryTier(tid, pid, item, fromBgThread);
+  return tryEvictToNextMemoryTier(tid, pid, item);
 }
 
 template <typename CacheTrait>
@@ -3096,7 +3523,7 @@ bool CacheAllocator<CacheTrait>::moveForSlabRelease(Item& oldItem) {
     // will send it back to the allocator
     bool isMoved = chainedItem
                        ? moveChainedItem(oldItem.asChainedItem(), newItemHdl)
-                       : moveRegularItem(oldItem, newItemHdl);
+                       : moveRegularItem(oldItem, newItemHdl, false, false);
     if (!isMoved) {
       return false;
     }
@@ -3176,7 +3603,6 @@ CacheAllocator<CacheTrait>::allocateNewItemForOldItem(const Item& oldItem) {
                                      oldItem.getSize(),
                                      oldItem.getCreationTime(),
                                      oldItem.getExpiryTime(),
-                                     false,
                                      evict);
   if (!newItemHdl) {
     return {};

--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -472,11 +472,10 @@ CacheAllocator<CacheTrait>::allocateInternalTier(TierId tid,
                            tid, pid, cid, backgroundEvictor_.size())]
         ->wakeUp();
   }
-
-  if (memory == nullptr) {
-    if (!evict) {
-      return {};
-    }
+  
+  if ((memory == nullptr && !evict) || (memory == nullptr && config_.noOnlineEviction)) {
+    return {};
+  } else if (memory == nullptr) {
     memory = findEviction(tid, pid, cid);
   }
 
@@ -1959,7 +1958,7 @@ CacheAllocator<CacheTrait>::getNextCandidate(TierId tid,
   bool isExpired = false;
   bool chainedItem = false;
   auto& mmContainer = getMMContainer(tid, pid, cid);
-  bool lastTier = tid+1 >= getNumTiers();
+  bool lastTier = tid+1 >= getNumTiers() || config_.noOnlineEviction;
 
   mmContainer.withEvictionIterator([this, tid, pid, cid, &candidate,
                                     &toRecycle, &toRecycleParent,

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -354,6 +354,38 @@ class CacheAllocator : public CacheBase {
     virtual bool isValid() const { return true; }
   };
   using ChainedItemMovingSync = std::function<std::unique_ptr<SyncObj>(Key)>;
+  
+  // Eviction related data returned from
+  // function executed under mmContainer lock
+  struct EvictionData {
+    EvictionData() = delete;
+    EvictionData(Item *candidate_, 
+                 Item *toRecycle_,
+                 Item *toRecycleParent_,
+                 bool chainedItem_,
+                 bool expired_,
+                 typename NvmCacheT::PutToken token_,
+                 WriteHandle candidateHandle_) :
+                 candidate(candidate_),
+                 toRecycle(toRecycle_),
+                 toRecycleParent(toRecycleParent_),
+                 expired(expired_),
+                 chainedItem(chainedItem_),
+                 token(std::move(token_)),
+                 candidateHandle(std::move(candidateHandle_)) {}
+
+    // item that is candidate for eviction
+    Item *candidate;
+    // acutal alloc that will be recycled
+    // back up to allocator
+    Item *toRecycle;
+    // possible parent ref
+    Item *toRecycleParent;
+    bool expired; //is item expired
+    bool chainedItem; //is it a chained item
+    typename NvmCacheT::PutToken token; //put token for NVM cache
+    WriteHandle candidateHandle; //hande in case we don't use moving bit
+  };
 
   using AccessContainer = typename Item::AccessContainer;
   using MMContainer = typename Item::MMContainer;
@@ -1522,16 +1554,12 @@ class CacheAllocator : public CacheBase {
                                Key key,
                                uint32_t size,
                                uint32_t creationTime,
-                               uint32_t expiryTime,
-                               bool fromBgThread = false);
+                               uint32_t expiryTime);
 
   // create a new cache allocation on specific memory tier.
   // For description see allocateInternal.
   //
   // @param tid id a memory tier
-  // @param fromBgThread whether this function was called from a bg
-  //        thread - this is used to decide whether bg thread should
-  //        be waken in case there is no free memory
   // @param evict whether to evict an item from tier tid in case there
   //        is not enough memory
   WriteHandle allocateInternalTier(TierId tid,
@@ -1540,8 +1568,35 @@ class CacheAllocator : public CacheBase {
                                    uint32_t size,
                                    uint32_t creationTime,
                                    uint32_t expiryTime,
-                                   bool fromBgThread,
                                    bool evict);
+  
+  // create a new cache allocation on specific memory tier,
+  // for a given class id. used in moving between tiers since
+  // class id's are the same among the tiers.
+  // For description see allocateInternal.
+  //
+  // @param tid id a memory tier
+  // @param pid a poold id
+  // @param cid a class id
+  //
+  void* allocateInternalTierByCid(TierId tid,
+                                   PoolId pid,
+                                   ClassId cid);
+
+  // create a new cache allocation on specific memory tier,
+  // for a given class id. used in moving between tiers since
+  // class id's are the same among the tiers.
+  // For description see allocateInternal.
+  //
+  // @param tid id a memory tier
+  // @param pid a poold id
+  // @param cid a class id
+  // @param batch the number of allocations to make
+  //
+  std::vector<void*> allocateInternalTierByCidBatch(TierId tid,
+                                   PoolId pid,
+                                   ClassId cid,
+                                   uint64_t batch);
 
   // Allocate a chained item
   //
@@ -1647,10 +1702,12 @@ class CacheAllocator : public CacheBase {
   //
   // @param oldItem     item being moved
   // @param newItemHdl  Reference to the handle of the new item being moved into
-  //
+  // @param skipAddInMMContainer so we can tell if we should add in mmContainer or wait
+  //                     to do in batch
+  // @param fromBgThread use memmove instead of memcopy (for DTO testing)
   // @return true  If the move was completed, and the containers were updated
   //               successfully.
-  bool moveRegularItem(Item& oldItem, WriteHandle& newItemHdl);
+  bool moveRegularItem(Item& oldItem, WriteHandle& newItemHdl, bool skipAddInMMContainer, bool fromBgThread);
 
   // template class for viewAsChainedAllocs that takes either ReadHandle or
   // WriteHandle
@@ -1817,6 +1874,7 @@ class CacheAllocator : public CacheBase {
   // @return An evicted item or nullptr  if there is no suitable candidate found
   // within the configured number of attempts.
   Item* findEviction(TierId tid, PoolId pid, ClassId cid);
+  std::vector<Item*> findEvictionBatch(TierId tid, PoolId pid, ClassId cid, unsigned int batch);
 
   // Get next eviction candidate from MMContainer, remove from AccessContainer,
   // MMContainer and insert into NVMCache if enabled.
@@ -1835,47 +1893,62 @@ class CacheAllocator : public CacheBase {
                                            unsigned int& searchTries);
 
   using EvictionIterator = typename MMContainer::LockedIterator;
+  // similiar to the above method but returns a batch of evicted items
+  // as a pair of vectors
+  std::vector<EvictionData> getNextCandidates(TierId tid,
+                                              PoolId pid,
+                                              ClassId cid,
+                                              unsigned int batch,
+                                              bool markMoving,
+                                              bool fromBgThread);
+  
+  std::vector<Item*> getNextCandidatesPromotion(TierId tid,
+                                       PoolId pid,
+                                       ClassId cid,
+                                       unsigned int batch,
+                                       bool markMoving,
+                                       bool fromBgThread);
+
+  // 
+  // Common function in case move among tiers fails during eviction
+  // @param candidate that failed to move
+  // @param the corresponding put token
+  // @param if we are on the last tier
+  // @param if candidate is expired
+  // @param if we are using moving bit
+  //
+  // if insertOrReplace was called during move
+  // then candidate will not be accessible (failed replace during tryEvict)
+  //  - therefore this was why we failed to
+  //    evict to the next tier and insertOrReplace
+  //    will remove from NVM cache
+  // however, if candidate is accessible
+  // that means the allocation in the next
+  // tier failed - so we will continue to
+  // evict the item to NVM cache
+  bool handleFailedMove(Item* candidate, 
+                        typename NvmCacheT::PutToken& token, 
+                        bool isExpired,
+                        bool markMoving);
 
   // Try to move the item down to the next memory tier
   //
   // @param tid current tier ID of the item
   // @param pid the pool ID the item belong to.
   // @param item the item to evict
-  // @param fromBgThread whether this is called from BG thread
   //
   // @return valid handle to the item. This will be the last
   //         handle to the item. On failure an empty handle.
-  WriteHandle tryEvictToNextMemoryTier(TierId tid, PoolId pid, Item& item,
-                                       bool fromBgThread);
+  WriteHandle tryEvictToNextMemoryTier(TierId tid, PoolId pid, Item& item);
 
   // Try to move the item down to the next memory tier
   //
   // @param item the item to evict
-  // @param fromBgThread whether this is called from BG thread
   //
   // @return valid handle to the item. This will be the last
   //         handle to the item. On failure an empty handle. 
-  WriteHandle tryEvictToNextMemoryTier(Item& item, bool fromBgThread);
+  WriteHandle tryEvictToNextMemoryTier(Item& item);
 
-  // Try to move the item up to the next memory tier
-  //
-  // @param tid current tier ID of the item
-  // @param pid the pool ID the item belong to.
-  // @param item the item to promote
-  // @param fromBgThread whether this is called from BG thread
-  //
-  // @return valid handle to the item. This will be the last
-  //         handle to the item. On failure an empty handle.
-  WriteHandle tryPromoteToNextMemoryTier(TierId tid, PoolId pid, Item& item, bool fromBgThread);
-
-  // Try to move the item up to the next memory tier
-  //
-  // @param item the item to promote
-  // @param fromBgThread whether this is called from BG thread
-  //
-  // @return valid handle to the item. This will be the last
-  //         handle to the item. On failure an empty handle.
-  WriteHandle tryPromoteToNextMemoryTier(Item& item, bool fromBgThread);
 
   // Wakes up waiters if there are any
   //
@@ -2016,161 +2089,25 @@ class CacheAllocator : public CacheBase {
                                size_t batch) {
     util::LatencyTracker tracker{stats().bgEvictLatency_, batch};
     auto& mmContainer = getMMContainer(tid, pid, cid);
-    size_t evictions = 0;
-    size_t evictionCandidates = 0;
-    std::vector<Item*> candidates;
-    candidates.reserve(batch);
-
-    size_t tries = 0;
-    mmContainer.withEvictionIterator([&tries, &candidates, &batch, &mmContainer, this](auto &&itr) {
-      while (candidates.size() < batch && 
-        (config_.maxEvictionPromotionHotness == 0 || tries < config_.maxEvictionPromotionHotness) && 
-         itr) {
-        tries++;
-        Item* candidate = itr.get();
-        XDCHECK(candidate);
-
-        if (candidate->isChainedItem()) {
-          throw std::runtime_error("Not supported for chained items");
-        }
-
-        if (candidate->markMoving()) {
-          mmContainer.remove(itr);
-          candidates.push_back(candidate);
-        } else {
-            ++itr;
-        }
+    uint32_t currItems = mmContainer.size();
+    if (currItems < batch) {
+      batch = currItems;
+      if (batch == 0) {
+        return 0;
       }
-    });
-
-    for (Item *candidate : candidates) {
-      auto evictedToNext = tryEvictToNextMemoryTier(*candidate, true /* from BgThread */);
-      if (!evictedToNext) {
-	  auto token = createPutToken(*candidate);
-
-	  auto ret = candidate->markForEvictionWhenMoving();
-	  XDCHECK(ret);
-
-          unlinkItemForEviction(*candidate);
-      	  // wake up any readers that wait for the move to complete
-      	  // it's safe to do now, as we have the item marked exclusive and
-      	  // no other reader can be added to the waiters list
-      	  wakeUpWaiters(candidate->getKey(), WriteHandle{});
-
-      	  if (token.isValid() && shouldWriteToNvmCacheExclusive(*candidate)) {
-      	    nvmCache_->put(*candidate, std::move(token));
-      	  }
-      } else {
-          evictions++;
-      	  XDCHECK(!evictedToNext->isMarkedForEviction() && !evictedToNext->isMoving());
-      	  XDCHECK(!candidate->isMarkedForEviction() && !candidate->isMoving());
-      	  XDCHECK(!candidate->isAccessible());
-      	  XDCHECK(candidate->getKey() == evictedToNext->getKey());
-
-      	  wakeUpWaiters(candidate->getKey(), std::move(evictedToNext));
-      }
-      XDCHECK(!candidate->isMarkedForEviction() && !candidate->isMoving());
-
-      if (candidate->hasChainedItem()) {
-        (*stats_.chainedItemEvictions)[tid][pid][cid].inc();
-      } else {
-        (*stats_.regularItemEvictions)[tid][pid][cid].inc();
-      }
-
-      // it's safe to recycle the item here as there are no more
-      // references and the item could not been marked as moving
-      // by other thread since it's detached from MMContainer.
-      auto res = releaseBackToAllocator(*candidate, RemoveContext::kEviction,
-                                /* isNascent */ false);
-      XDCHECK(res == ReleaseRes::kReleased);
     }
+    auto evictionData = getNextCandidates(tid,pid,cid,batch,
+                                     true,true);
+    size_t evictions = evictionData.size();
+    (*stats_.regularItemEvictions)[tid][pid][cid].add(evictions);
     return evictions;
   }
-
-  size_t traverseAndPromoteItems(unsigned int tid,
-                                 unsigned int pid,
-                                 unsigned int cid,
-                                 size_t batch) {
+  
+  size_t traverseAndPromoteItems(unsigned int tid, unsigned int pid, unsigned int cid, size_t batch) {
     util::LatencyTracker tracker{stats().bgPromoteLatency_, batch};
-    auto& mmContainer = getMMContainer(tid, pid, cid);
-    size_t promotions = 0;
-    std::vector<Item*> candidates;
-    candidates.reserve(batch);
-
-    size_t tries = 0;
-
-    mmContainer.withPromotionIterator([&tries, &candidates, &batch, &mmContainer, this](auto &&itr){
-      while (candidates.size() < batch && (config_.maxEvictionPromotionHotness == 0 || tries < config_.maxEvictionPromotionHotness) && itr) {
-        tries++;
-        Item* candidate = itr.get();
-        XDCHECK(candidate);
-
-        if (candidate->isChainedItem()) {
-          throw std::runtime_error("Not supported for chained items");
-        }
-
-        // TODO: only allow it for read-only items?
-        // or implement mvcc
-        if (candidate->markMoving()) {
-          // promotions should rarely fail since we already marked moving
-          mmContainer.remove(itr);
-          candidates.push_back(candidate);
-        }
-
-        ++itr;
-      }
-    });
-
-    for (Item *candidate : candidates) {
-      auto promoted = tryPromoteToNextMemoryTier(*candidate, true);
-      if (promoted) {
-        promotions++;
-        XDCHECK(!candidate->isMarkedForEviction() && !candidate->isMoving());
-        // it's safe to recycle the item here as there are no more
-        // references and the item could not been marked as moving
-        // by other thread since it's detached from MMContainer.
-        //
-        // but we need to wake up waiters before releasing
-        // since candidate's key can change after being sent
-        // back to allocator
-        wakeUpWaiters(candidate->getKey(), std::move(promoted));
-        auto res = releaseBackToAllocator(*candidate, RemoveContext::kEviction,
-                                  /* isNascent */ false);
-        XDCHECK(res == ReleaseRes::kReleased);
-      } else {
-        // we failed to allocate a new item, this item is no  longer moving
-        auto ref = candidate->unmarkMoving();
-        if (UNLIKELY(ref == 0)) {
-	  wakeUpWaiters(candidate->getKey(),{});
-          const auto res =
-              releaseBackToAllocator(*candidate, 
-                      RemoveContext::kNormal, false);
-          XDCHECK(res == ReleaseRes::kReleased);
-        } else if (candidate->isAccessible()) {
-          //case where we failed to allocate in lower tier
-          //item is still present in accessContainer
-          //item is no longer moving - acquire and
-          //wake up waiters with this handle
-	  auto hdl = acquire(candidate);
-	  insertInMMContainer(*hdl);
-	  wakeUpWaiters(candidate->getKey(), std::move(hdl));
-        } else if (!candidate->isAccessible()) {
-          //case where we failed to replace in access
-          //container due to another thread calling insertOrReplace
-          //unmark moving and return null handle
-	  wakeUpWaiters(candidate->getKey(), {});
-	  if (UNLIKELY(ref == 0)) {
-              const auto res =
-                releaseBackToAllocator(*candidate, RemoveContext::kNormal,
-                                        false);
-              XDCHECK(res == ReleaseRes::kReleased);
-          }
-        } else {
-          XDCHECK(false);
-        }
-      }
-    }
-    return promotions;
+    auto candidates = getNextCandidatesPromotion(tid,pid,cid,batch,
+                                     true,true);
+    return candidates.size();
   }
 
   // returns true if nvmcache is enabled and we should write this item to
@@ -2500,7 +2437,7 @@ class CacheAllocator : public CacheBase {
   // free memory monitor
   std::unique_ptr<MemoryMonitor> memMonitor_;
 
-  // background evictor
+  // background data movement
   std::vector<std::unique_ptr<BackgroundMover<CacheT>>> backgroundEvictor_;
   std::vector<std::unique_ptr<BackgroundMover<CacheT>>> backgroundPromoter_;
 

--- a/cachelib/allocator/CacheAllocatorConfig.h
+++ b/cachelib/allocator/CacheAllocatorConfig.h
@@ -315,6 +315,8 @@ class CacheAllocatorConfig {
 
   // Insert items to first free memory tier
   CacheAllocatorConfig& enableInsertToFirstFreeTier();
+  
+  CacheAllocatorConfig& enableNoOnlineEviction();
 
   // Passes in a callback to initialize an event tracker when the allocator
   // starts
@@ -547,6 +549,8 @@ class CacheAllocatorConfig {
   // from the bottom one if memory cache is full
   bool insertToFirstFreeTier = false;
 
+  bool noOnlineEviction = false;
+
   // the number of tries to search for an item to evict
   // 0 means it's infinite
   unsigned int evictionSearchTries{50};
@@ -684,6 +688,12 @@ class CacheAllocatorConfig {
 template <typename T>
 CacheAllocatorConfig<T>& CacheAllocatorConfig<T>::enableInsertToFirstFreeTier() {
   insertToFirstFreeTier = true;
+  return *this;
+}
+
+template <typename T>
+CacheAllocatorConfig<T>& CacheAllocatorConfig<T>::enableNoOnlineEviction() {
+  noOnlineEviction = true;
   return *this;
 }
 
@@ -1269,6 +1279,7 @@ std::map<std::string, std::string> CacheAllocatorConfig<T>::serialize() const {
   configMap["delayCacheWorkersStart"] =
       delayCacheWorkersStart ? "true" : "false";
   configMap["insertToFirstFreeTier"] = std::to_string(insertToFirstFreeTier);
+  configMap["noOnlineEviction"] = std::to_string(noOnlineEviction);
   mergeWithPrefix(configMap, throttleConfig.serialize(), "throttleConfig");
   mergeWithPrefix(configMap,
                   chainedItemAccessConfig.serialize(),

--- a/cachelib/allocator/FreeThresholdStrategy.cpp
+++ b/cachelib/allocator/FreeThresholdStrategy.cpp
@@ -34,14 +34,18 @@ std::vector<size_t> FreeThresholdStrategy::calculateBatchSizes(
     std::vector<MemoryDescriptorType> acVec) {
   std::vector<size_t> batches{};
   for (auto [tid, pid, cid] : acVec) {
-    auto stats = cache.getACStats(tid, pid, cid);
-    if ((1-stats.usageFraction())*100 >= highEvictionAcWatermark) {
+    const auto& pool = cache.getPoolByTid(pid, tid);
+    if (pool.getApproxFreeSlabs()) {
       batches.push_back(0);
-    } else {
-      auto toFreeMemPercent = highEvictionAcWatermark - (1-stats.usageFraction())*100;
+    }
+    double usage = pool.getApproxUsage(cid);
+    if ((1-usage)*100 < highEvictionAcWatermark && pool.allSlabsAllocated()) {
+      auto toFreeMemPercent = highEvictionAcWatermark - (1-usage)*100;
       auto toFreeItems = static_cast<size_t>(
-          toFreeMemPercent * (stats.totalSlabs() * Slab::kSize) / stats.allocSize);
+          toFreeMemPercent * (pool.getApproxSlabs(cid) * pool.getPerSlab(cid)) );
       batches.push_back(toFreeItems);
+    } else {
+      batches.push_back(0);
     }
   }
 

--- a/cachelib/allocator/MM2Q-inl.h
+++ b/cachelib/allocator/MM2Q-inl.h
@@ -227,16 +227,41 @@ bool MM2Q::Container<T, HookPtr>::add(T& node) noexcept {
     if (node.isInMMContainer()) {
       return false;
     }
-
-    markHot(node);
-    unmarkCold(node);
-    unmarkTail(node);
-    lru_.getList(LruType::Hot).linkAtHead(node);
-    rebalance();
-
-    node.markInMMContainer();
-    setUpdateTime(node, currTime);
+    addNodeLocked(node, currTime);
     return true;
+  });
+}
+
+// adds the node to the list assuming not in 
+// container and holding container lock
+template <typename T, MM2Q::Hook<T> T::*HookPtr>
+void MM2Q::Container<T, HookPtr>::addNodeLocked(T& node, const Time& currTime) {
+  XDCHECK(!node.isInMMContainer());
+  markHot(node);
+  unmarkCold(node);
+  unmarkTail(node);
+  lru_.getList(LruType::Hot).linkAtHead(node);
+  rebalance();
+
+  node.markInMMContainer();
+  setUpdateTime(node, currTime);
+}
+
+template <typename T, MM2Q::Hook<T> T::*HookPtr>
+template <typename It>
+uint32_t MM2Q::Container<T, HookPtr>::addBatch(It begin, It end) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  return lruMutex_->lock_combine([this, begin, end, currTime]() {
+    uint32_t i = 0;
+    for (auto itr = begin; itr != end; itr++) {
+      T* node = *itr;
+      if (node->isInMMContainer()) {
+        return i;
+      }
+      addNodeLocked(*node,currTime);
+      i++;
+    }
+    return i;
   });
 }
 

--- a/cachelib/allocator/MM2Q.h
+++ b/cachelib/allocator/MM2Q.h
@@ -463,6 +463,18 @@ class MM2Q {
     //          is unchanged.
     bool add(T& node) noexcept;
 
+    // helper function to add the node under the container lock
+    void addNodeLocked(T& node, const Time& currTime);
+    
+    // adds the given nodes into the container and marks each as being present in
+    // the container. The nodes are added to the head of the lru.
+    //
+    // @param vector of nodes  The nodes to be added to the container.
+    // @return  number of nodes added - it is up to user to verify all
+    //          expected nodes have been added.
+    template <typename It>
+    uint32_t addBatch(It begin, It end) noexcept;
+
     // removes the node from the lru and sets it previous and next to nullptr.
     //
     // @param node  The node to be removed from the container.

--- a/cachelib/allocator/MMLru-inl.h
+++ b/cachelib/allocator/MMLru-inl.h
@@ -193,21 +193,47 @@ void MMLru::Container<T, HookPtr>::updateLruInsertionPoint() noexcept {
 template <typename T, MMLru::Hook<T> T::*HookPtr>
 bool MMLru::Container<T, HookPtr>::add(T& node) noexcept {
   const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
-
   return lruMutex_->lock_combine([this, &node, currTime]() {
     if (node.isInMMContainer()) {
       return false;
     }
-    if (config_.lruInsertionPointSpec == 0 || insertionPoint_ == nullptr) {
-      lru_.linkAtHead(node);
-    } else {
-      lru_.insertBefore(*insertionPoint_, node);
-    }
-    node.markInMMContainer();
-    setUpdateTime(node, currTime);
-    unmarkAccessed(node);
-    updateLruInsertionPoint();
+    addNodeLocked(node,currTime);
     return true;
+  });
+}
+
+template <typename T, MMLru::Hook<T> T::*HookPtr>
+void MMLru::Container<T, HookPtr>::addNodeLocked(T& node, const Time& currTime) {
+  XDCHECK(!node.isInMMContainer());
+  if (config_.lruInsertionPointSpec == 0 || insertionPoint_ == nullptr) {
+    lru_.linkAtHead(node);
+  } else {
+    lru_.insertBefore(*insertionPoint_, node);
+  }
+  node.markInMMContainer();
+  setUpdateTime(node, currTime);
+  unmarkAccessed(node);
+  updateLruInsertionPoint();
+}
+
+template <typename T, MMLru::Hook<T> T::*HookPtr>
+template <typename It>
+uint32_t MMLru::Container<T, HookPtr>::addBatch(It begin, It end) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  return lruMutex_->lock_combine([this, begin, end, currTime]() {
+    uint32_t i = 0;
+    for (auto itr = begin; itr != end; ++itr) {
+      T* node = *itr;
+      XDCHECK(!node->isInMMContainer());
+      if (node->isInMMContainer()) {
+        throw std::runtime_error(
+          folly::sformat("Was not able to add all new items, failed item {}",
+                          node->toString()));
+      }
+      addNodeLocked(*node,currTime);
+      i++;
+    }
+    return i;
   });
 }
 
@@ -231,8 +257,7 @@ void MMLru::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
 
 template <typename T, MMLru::Hook<T> T::*HookPtr>
 template <typename F>
-void
-MMLru::Container<T, HookPtr>::withPromotionIterator(F&& fun) {
+void MMLru::Container<T, HookPtr>::withPromotionIterator(F&& fun) {
   if (config_.useCombinedLockForIterators) {
     lruMutex_->lock_combine([this, &fun]() { fun(Iterator{lru_.begin()}); });
   } else {

--- a/cachelib/allocator/MMLru.h
+++ b/cachelib/allocator/MMLru.h
@@ -339,6 +339,18 @@ class MMLru {
     //          is unchanged.
     bool add(T& node) noexcept;
 
+    // helper function to add the node under the container lock
+    void addNodeLocked(T& node, const Time& currTime);
+    
+    // adds the given nodes into the container and marks each as being present in
+    // the container. The nodes are added to the head of the lru.
+    //
+    // @param vector of nodes  The nodes to be added to the container.
+    // @return  number of nodes added - it is up to user to verify all
+    //          expected nodes have been added.
+    template <typename It>
+    uint32_t addBatch(It begin, It end) noexcept;
+
     // removes the node from the lru and sets it previous and next to nullptr.
     //
     // @param node  The node to be removed from the container.

--- a/cachelib/allocator/MMTinyLFU-inl.h
+++ b/cachelib/allocator/MMTinyLFU-inl.h
@@ -182,7 +182,15 @@ bool MMTinyLFU::Container<T, HookPtr>::add(T& node) noexcept {
   if (node.isInMMContainer()) {
     return false;
   }
+  addNodeLocked(node, currTime);
+  return true;
+}
 
+// adds the node to the list assuming not in 
+// container and holding container lock
+template <typename T, MMTinyLFU::Hook<T> T::*HookPtr>
+void MMTinyLFU::Container<T, HookPtr>::addNodeLocked(T& node, const Time &currTime) {
+  XDCHECK(!node.isInMMContainer());
   auto& tinyLru = lru_.getList(LruType::Tiny);
   tinyLru.linkAtHead(node);
   markTiny(node);
@@ -210,7 +218,23 @@ bool MMTinyLFU::Container<T, HookPtr>::add(T& node) noexcept {
   node.markInMMContainer();
   setUpdateTime(node, currTime);
   unmarkAccessed(node);
-  return true;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::*HookPtr>
+template <typename It>
+uint32_t MMTinyLFU::Container<T, HookPtr>::addBatch(It begin, It end) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  LockHolder l(lruMutex_);
+  uint32_t i = 0;
+  for (auto itr = begin; itr != end; itr++) {
+    T* node = *itr;
+    if (node->isInMMContainer()) {
+      return i;
+    }
+    addNodeLocked(*node, currTime);
+    i++;
+  }
+  return i;
 }
 
 template <typename T, MMTinyLFU::Hook<T> T::*HookPtr>

--- a/cachelib/allocator/MMTinyLFU.h
+++ b/cachelib/allocator/MMTinyLFU.h
@@ -327,6 +327,18 @@ class MMTinyLFU {
     //          if the node was already in the contianer. On error state of node
     //          is unchanged.
     bool add(T& node) noexcept;
+    
+    // helper function to add the node under the container lock
+    void addNodeLocked(T& node, const Time& currTime);
+    
+    // adds the given nodes into the container and marks each as being present in
+    // the container. The nodes are added to the head of the lru.
+    //
+    // @param vector of nodes  The nodes to be added to the container.
+    // @return  number of nodes added - it is up to user to verify all
+    //          expected nodes have been added.
+    template <typename It>
+    uint32_t addBatch(It begin, It end) noexcept;
 
     // removes the node from the lru and sets it previous and next to nullptr.
     //

--- a/cachelib/allocator/PromotionStrategy.h
+++ b/cachelib/allocator/PromotionStrategy.h
@@ -38,13 +38,14 @@ class PromotionStrategy : public BackgroundMoverStrategy {
     std::vector<size_t> batches{};
     for (auto [tid, pid, cid] : acVec) {
       XDCHECK(tid > 0);
-      auto stats = cache.getACStats(tid - 1, pid, cid);
-      if ((1-stats.usageFraction())*100 < promotionAcWatermark)
+      const auto& pool = cache.getPoolByTid(pid, tid-1);
+      double usage = pool.getApproxUsage(cid);
+      if ((1-usage)*100 <= promotionAcWatermark)
         batches.push_back(0);
       else {
         auto maxPossibleItemsToPromote = static_cast<size_t>(
-            (promotionAcWatermark - (1-stats.usageFraction())*100) *
-            (stats.totalSlabs() * Slab::kSize) / stats.allocSize);
+            ( (promotionAcWatermark - (1-usage*100) ) *
+              (pool.getApproxSlabs(cid) * pool.getPerSlab(cid)) ) );
         batches.push_back(maxPossibleItemsToPromote);
       }
     }

--- a/cachelib/allocator/memory/AllocationClass.h
+++ b/cachelib/allocator/memory/AllocationClass.h
@@ -97,6 +97,13 @@ class AllocationClass {
   // fetch stats about this allocation class.
   ACStats getStats() const;
 
+  // get approx usage as fraction of used allocs/total allocs in this class
+  double getApproxUsage() const;
+  // get approx slabs in this class
+  uint32_t getApproxSlabs() const;
+  // get items per slabs in this class
+  uint32_t getPerSlab() const;
+
   // Whether the pool is full or free to allocate more in the current state.
   // This is only a hint and not a gurantee that subsequent allocate will
   // fail/succeed.

--- a/cachelib/allocator/memory/AllocationClass.h
+++ b/cachelib/allocator/memory/AllocationClass.h
@@ -116,6 +116,7 @@ class AllocationClass {
   //          don't have any free memory. The caller will have to add a slab
   //          to this slab class to make further allocations out of it.
   void* allocate();
+  std::vector<void*> allocateBatch(uint64_t batch);
 
   // @param ctx     release context for the slab owning this alloc
   // @param memory  memory to check
@@ -227,6 +228,7 @@ class AllocationClass {
   // @param slab    a new slab to be added. This can NOT be nullptr.
   // @return  new allocation. This cannot fail.
   void* addSlabAndAllocate(Slab* slab);
+  std::vector<void*> addSlabAndAllocateBatch(Slab* slab, uint64_t batch);
 
   // Releasing a slab is a two step process.
   // 1. Mark a slab for release, by calling `startSlabRelease`.

--- a/cachelib/allocator/memory/MemoryAllocator.cpp
+++ b/cachelib/allocator/memory/MemoryAllocator.cpp
@@ -71,6 +71,16 @@ void* MemoryAllocator::allocate(PoolId id, uint32_t size) {
   return mp.allocate(size);
 }
 
+void* MemoryAllocator::allocateByCid(PoolId id, ClassId cid) {
+  auto& mp = memoryPoolManager_.getPoolById(id);
+  return mp.allocateByCid(cid);
+}
+
+std::vector<void*> MemoryAllocator::allocateByCidBatch(PoolId id, ClassId cid, uint64_t batch) {
+  auto& mp = memoryPoolManager_.getPoolById(id);
+  return mp.allocateByCidBatch(cid, batch);
+}
+
 void* MemoryAllocator::allocateZeroedSlab(PoolId id) {
   if (!config_.enableZeroedSlabAllocs) {
     throw std::logic_error("Zeroed Slab allcoation is not enabled");

--- a/cachelib/allocator/memory/MemoryAllocator.h
+++ b/cachelib/allocator/memory/MemoryAllocator.h
@@ -167,6 +167,8 @@ class MemoryAllocator {
   // @throw std::invalid_argument if the poolId is invalid or the size is
   //        invalid.
   void* allocate(PoolId id, uint32_t size);
+  void* allocateByCid(PoolId id, ClassId cid);
+  std::vector<void*> allocateByCidBatch(PoolId id, ClassId cid, uint64_t batch);
 
   // Allocate a zeroed Slab
   //

--- a/cachelib/allocator/memory/MemoryAllocatorStats.h
+++ b/cachelib/allocator/memory/MemoryAllocatorStats.h
@@ -53,6 +53,9 @@ struct ACStats {
   // Rolling allocation latency (in ns)
   util::RollingStats allocLatencyNs;
 
+  uint64_t evictionAttempts;
+  uint64_t evictions;
+
   constexpr unsigned long long totalSlabs() const noexcept {
     return freeSlabs + usedSlabs;
   }
@@ -66,6 +69,15 @@ struct ACStats {
       return 0.0;
 
     return activeAllocs / (usedSlabs * allocsPerSlab);
+  }
+
+  constexpr double approxUsage() const noexcept {
+    const unsigned long long nSlabsAllocated = usedSlabs;
+    if (nSlabsAllocated == 0) {
+        return 0.0;
+    }
+    const unsigned long long perSlab = allocsPerSlab;
+    return (double) activeAllocs / (double) (nSlabsAllocated * perSlab);
   }
 
   constexpr size_t totalAllocatedSize() const noexcept {

--- a/cachelib/allocator/memory/MemoryAllocatorStats.h
+++ b/cachelib/allocator/memory/MemoryAllocatorStats.h
@@ -70,7 +70,7 @@ struct ACStats {
 
     return activeAllocs / (usedSlabs * allocsPerSlab);
   }
-
+  
   constexpr double approxUsage() const noexcept {
     const unsigned long long nSlabsAllocated = usedSlabs;
     if (nSlabsAllocated == 0) {

--- a/cachelib/allocator/memory/MemoryPool.cpp
+++ b/cachelib/allocator/memory/MemoryPool.cpp
@@ -523,3 +523,22 @@ MPStats MemoryPool::getStats() const {
                  slabsUnAllocated,    nSlabResize_,       nSlabRebalance_,
                  curSlabsAdvised_};
 }
+
+double MemoryPool::getApproxUsage(ClassId cid) const {
+  const auto& ac = getAllocationClassFor(cid);
+  return ac.getApproxUsage();
+}
+
+uint32_t MemoryPool::getApproxFreeSlabs() const {
+  return freeSlabs_.size();
+}
+
+uint32_t MemoryPool::getApproxSlabs(ClassId cid) const {
+  const auto& ac = getAllocationClassFor(cid);
+  return ac.getApproxSlabs();
+}
+
+uint32_t MemoryPool::getPerSlab(ClassId cid) const {
+  const auto& ac = getAllocationClassFor(cid);
+  return ac.getPerSlab();
+}

--- a/cachelib/allocator/memory/MemoryPool.cpp
+++ b/cachelib/allocator/memory/MemoryPool.cpp
@@ -262,12 +262,71 @@ Slab* MemoryPool::getSlabLocked() noexcept {
   return slab;
 }
 
-void* MemoryPool::allocate(uint32_t size) {
-  auto& ac = getAllocationClassFor(size);
+std::vector<void*> MemoryPool::allocateForClassBatch(AllocationClass& ac, uint64_t batch) {
+  uint64_t total = 0;
+  const auto allocSize = ac.getAllocSize();
+  auto allocs = ac.allocateBatch(batch);
+  if (allocs.size() > 0) {
+    total += allocs.size();
+    currAllocSize_ += allocSize * allocs.size();
+  }
+  if (total == batch) {
+    return allocs;
+  }
 
+  // atomically see if we can acquire a slab by checking if we have
+  // reached the limit by size. If not, then they can be acquired from
+  // either the slab allocator or our free list. It is important to check
+  // this before we grab it from the slab allocator or free list. Things
+  // that release slab, bump down the currSlabAllocSize_ after actually
+  // releasing and adding it to free list or slab allocator.
+  if (allSlabsAllocated()) {
+    return allocs;
+  }
+
+  uint32_t remain = batch - total;
+  // TODO: introduce a new sharded lock by allocation class id for this slow
+  // path Currently this would also serialize the slow paths of two different
+  // allocation class ids that need slab to initiate an allocation.
+  LockHolder l(lock_);
+  auto allocs2 = ac.allocateBatch(remain);
+  if (allocs2.size() > 0) {
+    total += allocs2.size();
+    currAllocSize_ += allocSize * allocs2.size();
+    allocs.insert(allocs.end(),allocs2.begin(),allocs2.end());
+  }
+  if (total == batch) {
+    return allocs;
+  }
+
+  remain = batch - total;
+  // see if we have a slab to add to the allocation class.
+  auto slab = getSlabLocked();
+  while (remain && slab != nullptr) {
+    if (slab == nullptr) {
+      // out of memory
+      return allocs;
+    }
+
+    // add it to the allocation class and try to allocate.
+    auto allocs3 = ac.addSlabAndAllocateBatch(slab, remain);
+    //XDCHECK_NE(nullptr, alloc);
+
+    currAllocSize_ += allocSize * allocs3.size();
+    total += allocs3.size();
+    remain -= allocs3.size();
+    allocs.insert(allocs.end(),allocs3.begin(),allocs3.end());
+    if (total == batch) {
+      return allocs;
+    }
+    slab = getSlabLocked();
+  }
+  return allocs;
+}
+
+void* MemoryPool::allocateForClass(AllocationClass& ac) {
   auto alloc = ac.allocate();
   const auto allocSize = ac.getAllocSize();
-  XDCHECK_GE(allocSize, size);
 
   if (alloc != nullptr) {
     currAllocSize_ += allocSize;
@@ -307,6 +366,23 @@ void* MemoryPool::allocate(uint32_t size) {
 
   currAllocSize_ += allocSize;
   return alloc;
+}
+
+void* MemoryPool::allocateByCid(ClassId cid) {
+  auto& ac = getAllocationClassFor(cid);
+  return allocateForClass(ac);
+}
+
+std::vector<void*> MemoryPool::allocateByCidBatch(ClassId cid, uint64_t batch) {
+  auto& ac = getAllocationClassFor(cid);
+  return allocateForClassBatch(ac, batch);
+}
+
+void* MemoryPool::allocate(uint32_t size) {
+  auto& ac = getAllocationClassFor(size);
+  const auto allocSize = ac.getAllocSize();
+  XDCHECK_GE(allocSize, size);
+  return allocateForClass(ac);
 }
 
 void* MemoryPool::allocateZeroedSlab() { return allocate(Slab::kSize); }

--- a/cachelib/allocator/memory/MemoryPool.h
+++ b/cachelib/allocator/memory/MemoryPool.h
@@ -132,6 +132,14 @@ class MemoryPool {
   }
 
   MPStats getStats() const;
+  // approx usage fraction per class
+  double getApproxUsage(ClassId cid) const;
+  // approx slabs assigned to a given class
+  uint32_t getApproxSlabs(ClassId cid) const;
+  
+  uint32_t getApproxFreeSlabs() const;
+  // items per slab for a class
+  uint32_t getPerSlab(ClassId cid) const;
 
   // allocates memory of at least _size_ bytes.
   //

--- a/cachelib/allocator/memory/MemoryPool.h
+++ b/cachelib/allocator/memory/MemoryPool.h
@@ -147,6 +147,8 @@ class MemoryPool {
   // @return pointer to allocation or nullptr on failure to allocate.
   // @throw  std::invalid_argument if size is invalid.
   void* allocate(uint32_t size);
+  void* allocateByCid(ClassId cid);
+  std::vector<void*> allocateByCidBatch(ClassId cid, uint64_t batch);
 
   // Allocate a slab with zeroed memory
   //
@@ -331,6 +333,9 @@ class MemoryPool {
 
   // create allocation classes corresponding to the pool's configuration.
   ACVector createAllocationClasses() const;
+  
+  void* allocateForClass(AllocationClass& ac);
+  std::vector<void*> allocateForClassBatch(AllocationClass& ac, uint64_t batch);
 
   // @return  AllocationClass corresponding to the memory, if it
   //          belongs to an AllocationClass

--- a/cachelib/allocator/tests/AllocatorMemoryTiersTest.h
+++ b/cachelib/allocator/tests/AllocatorMemoryTiersTest.h
@@ -194,7 +194,7 @@ class AllocatorMemoryTiersTest : public AllocatorTest<AllocatorT> {
     const auto& mpStats = allocator->getPoolByTid(poolId, 0).getStats(); 
     //cache is 10MB should move about 1MB to reach 10% free
     uint32_t approxEvict = (1024*1024)/mpStats.acStats.at(cid).allocSize;
-    while (stats.evictionStats.numMovedItems < approxEvict*0.95 && (1-slabStats.usageFraction()) >= 0.095) {
+    while (stats.evictionStats[0].numMovedItems < approxEvict*0.95 && (1-slabStats.usageFraction()) >= 0.095) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
         stats = allocator->getGlobalCacheStats();
         slabStats = allocator->getACStats(0,0,cid);
@@ -204,12 +204,14 @@ class AllocatorMemoryTiersTest : public AllocatorTest<AllocatorT> {
     auto perclassEstats = allocator->getBackgroundMoverClassStats(MoverDir::Evict);
     auto perclassPstats = allocator->getBackgroundMoverClassStats(MoverDir::Promote);
 
-    ASSERT_GE(stats.evictionStats.numMovedItems,1);
-    ASSERT_GE(stats.evictionStats.runCount,1);
-    ASSERT_GE(stats.promotionStats.numMovedItems,1);
-   
-    ASSERT_GE(perclassEstats[0][0][cid], 1);
-    ASSERT_GE(perclassPstats[1][0][cid], 1);
+    ASSERT_GE(stats.evictionStats[0].numMovedItems,1);
+    ASSERT_GE(stats.evictionStats[0].runCount,1);
+    ASSERT_GE(stats.promotionStats[0].numMovedItems,1);
+    
+    MemoryDescriptorType tier0(0,0,cid);
+    MemoryDescriptorType tier1(1,0,cid);
+    ASSERT_GE(perclassEstats[tier0], 1);
+    ASSERT_GE(perclassPstats[tier1], 1);
     
   }
 

--- a/cachelib/cachebench/CMakeLists.txt
+++ b/cachelib/cachebench/CMakeLists.txt
@@ -51,6 +51,10 @@ endif()
 add_executable (cachebench main.cpp)
 target_link_libraries(cachebench cachelib_cachebench)
 
+if (BUILD_WITH_DTO)
+    target_link_libraries(cachebench accel-config dto)
+endif ()
+
 install(
   TARGETS
      cachebench

--- a/cachelib/cachebench/cache/Cache-inl.h
+++ b/cachelib/cachebench/cache/Cache-inl.h
@@ -105,6 +105,7 @@ Cache<Allocator>::Cache(const CacheConfig& config,
   }
 
   allocatorConfig_.insertToFirstFreeTier = config_.insertToFirstFreeTier;
+  allocatorConfig_.noOnlineEviction = config_.noOnlineEviction;
 
   auto cleanupGuard = folly::makeGuard([&] {
     if (!nvmCacheFilePath_.empty()) {

--- a/cachelib/cachebench/cache/CacheStats.h
+++ b/cachelib/cachebench/cache/CacheStats.h
@@ -27,31 +27,10 @@ namespace facebook {
 namespace cachelib {
 namespace cachebench {
 
-struct BackgroundEvictionStats {
-  // the number of items this worker evicted by looking at pools/classes stats
-  uint64_t nEvictedItems{0};
-
-  // number of times we went executed the thread //TODO: is this def correct?
-  uint64_t nTraversals{0};
-
-  // number of classes
-  uint64_t nClasses{0};
-
-  // size of evicted items
-  uint64_t evictionSize{0};
-};
-
-struct BackgroundPromotionStats {
-  // the number of items this worker evicted by looking at pools/classes stats
-  uint64_t nPromotedItems{0};
-
-  // number of times we went executed the thread //TODO: is this def correct?
-  uint64_t nTraversals{0};
-};
 
 struct Stats {
-  BackgroundEvictionStats backgndEvicStats;
-  BackgroundPromotionStats backgndPromoStats;
+  std::vector<BackgroundMoverStats> backgroundEvictorStats;
+  std::vector<BackgroundMoverStats> backgroundPromoStats;
   ReaperStats reaperStats;
 
   std::vector<uint64_t> numEvictions;
@@ -132,15 +111,17 @@ struct Stats {
   uint64_t invalidDestructorCount{0};
   int64_t unDestructedItemCount{0};
 
-  std::map<TierId, std::map<PoolId, std::map<ClassId, ACStats>>> allocationClassStats;
+  std::map<MemoryDescriptorType, ACStats> allocationClassStats;
 
   // populate the counters related to nvm usage. Cache implementation can decide
   // what to populate since not all of those are interesting when running
   // cachebench.
   std::unordered_map<std::string, double> nvmCounters;
+  
+  using ClassBgStatsType = std::map<MemoryDescriptorType,uint64_t>;
 
-  std::map<TierId, std::map<PoolId, std::map<ClassId, uint64_t>>> backgroundEvictionClasses;
-  std::map<TierId, std::map<PoolId, std::map<ClassId, uint64_t>>> backgroundPromotionClasses;
+  ClassBgStatsType backgroundEvictionClasses;
+  ClassBgStatsType backgroundPromotionClasses;
 
   // errors from the nvm engine.
   std::unordered_map<std::string, double> nvmErrors;
@@ -154,32 +135,34 @@ struct Stats {
     }
     out << folly::sformat("Items in NVM    : {:,}", numNvmItems) << std::endl;
     for (TierId tid = 0; tid < nTiers; tid++) {
-        out << folly::sformat("Tier {} Alloc Attempts: {:,} Success: {:.2f}%",
-                              tid,
-                              allocAttempts[tid],
-                              invertPctFn(allocFailures[tid], allocAttempts[tid]))
+        out << folly::sformat("Tier {} Alloc Attempts: {:,}\n"
+                              "Tier {} Alloc Success: {:.2f}%",
+                              tid, allocAttempts[tid],
+                              tid, invertPctFn(allocFailures[tid], allocAttempts[tid]))
             << std::endl;
     }
     for (TierId tid = 0; tid < nTiers; tid++) {
         out << folly::sformat(
-                   "Tier {} Evict Attempts: {:,} Success: {:.2f}%",
-                   tid,
-                   evictAttempts[tid],
-                   pctFn(numEvictions[tid], evictAttempts[tid]))
+                   "Tier {} Evict Attempts: {:,}\n"
+                   "Tier {} Success: {:.2f}%",
+                   tid, evictAttempts[tid],
+                   tid, invertPctFn(evictAttempts[tid] - numEvictions[tid], evictAttempts[tid]))
             << std::endl;
     }
     for (TierId tid = 0; tid < nTiers; tid++) {
-        out << folly::sformat("Tier {} Evictions : {:,} Writebacks: {:,} Success: {:.2f}%",
-                tid, numEvictions[tid], numWritebacks[tid],
-                invertPctFn(numEvictions[tid] - numWritebacks[tid], numEvictions[tid])) << std::endl;
+        out << folly::sformat("Tier {} Evictions: {:,}\n"
+                              "Tier {} Writebacks: {:,}\n"
+                              "Tier {} Success: {:.2f}%",
+                              tid, numEvictions[tid],
+                              tid, numWritebacks[tid],
+                              tid, invertPctFn(numEvictions[tid] - numWritebacks[tid], numEvictions[tid]))
+            << std::endl;
     }
+    
     auto foreachAC = [&](auto &map, auto cb) {
-      for (auto &tidStat : map) {
-        for (auto &pidStat : tidStat.second) {
-          for (auto &cidStat : pidStat.second) {
-            cb(tidStat.first, pidStat.first, cidStat.first, cidStat.second);
-          }
-        }
+      for (const auto& [key, value] : map) {
+        auto [tid,pid,cid] = key;
+        cb(tid, pid, cid, value);
       }
     };
 
@@ -217,16 +200,12 @@ struct Stats {
       };
 
       auto foreachAC = [&](auto cb) {
-        for (auto& tidStat : allocationClassStats) {
-          for (auto& pidStat : tidStat.second) {
-            for (auto& cidStat : pidStat.second) {
-              cb(tidStat.first, pidStat.first, cidStat.first, cidStat.second);
-            }
-          }
+        for (const auto& [key, value] : allocationClassStats) {
+          auto [tid,pid,cid] = key;
+          cb(tid, pid, cid, value);
         }
       };
-
-
+ 
       foreachAC([&](auto tid, auto pid, auto cid, auto stats) {
         auto [allocSizeSuffix, allocSize] = formatMemory(stats.allocSize);
         auto [memorySizeSuffix, memorySize] =
@@ -234,25 +213,60 @@ struct Stats {
 
         // If the pool is not full, extrapolate usageFraction for AC assuming it
         // will grow at the same rate. This value will be the same for all ACs.
-        const auto acUsageFraction = (poolUsageFraction.at(tid)[pid] < 1.0)
-                                   ? poolUsageFraction.at(tid)[pid]
-                                   : stats.usageFraction();
-
-        out << folly::sformat(
-                   "tid{:2} pid{:2} cid{:4} {:8.2f}{} usageFraction: {:4.2f} "
-                   "memorySize: {:8.2f}{} "
-                   "rollingAvgAllocLatency: {:8.2f}ns",
+        if (memorySize > 0) {
+          const auto acUsageFraction = stats.approxUsage();
+          out << folly::sformat(
+                   "tid{:2} pid{:2} cid{:4} {:8.2f}{} usage fraction: {:4.2f}\n"
+                   "tid{:2} pid{:2} cid{:4} {:8.2f}{} memory size in {}: {:8.2f}\n"
+                   "tid{:2} pid{:2} cid{:4} {:8.2f}{} eviction success: {:4.2f}\n"
+                   "tid{:2} pid{:2} cid{:4} {:8.2f}{} rolling avg alloc latency in ns: {:8.2f}",
                    tid, pid, cid, allocSize, allocSizeSuffix, acUsageFraction,
-                   memorySize, memorySizeSuffix,
-                   stats.allocLatencyNs.estimate())
+                   tid, pid, cid, allocSize, allocSizeSuffix, memorySizeSuffix, memorySize,
+                   tid, pid, cid, allocSize, allocSizeSuffix, (double)(stats.evictions/(double)stats.evictionAttempts),
+                   tid, pid, cid, allocSize, allocSizeSuffix, stats.allocLatencyNs.estimate())
             << std::endl;
+        }
       });
     }
 
-    out << folly::sformat("Tier 0 Background Evicted Items : {:,}",
-                            backgndEvicStats.nEvictedItems) << std::endl;
-    out << folly::sformat("Tier 0 Background Traversals : {:,}",
-                            backgndEvicStats.nTraversals) << std::endl;
+    int bgId = 1;
+    for (auto &bgWorkerStats : backgroundEvictorStats) {
+        if (bgWorkerStats.numMovedItems > 0) {
+          out << folly::sformat(" == Background Evictor Threads ==") << std::endl;
+          out << folly::sformat("Background Evictor Thread {} Evicted Items: {:,}\n"
+                                "Background Evictor Thread {} Traversals: {:,}\n"
+                                "Background Evictor Thread {} Run Count: {:,}\n"
+                                "Background Evictor Thread {} Avg Time Per Traversal in ns: {:,}\n"
+                                "Background Evictor Thread {} Avg Items Evicted: {:.2f}",
+                                bgId, bgWorkerStats.numMovedItems,
+                                bgId, bgWorkerStats.numTraversals,
+                                bgId, bgWorkerStats.runCount,
+                                bgId, bgWorkerStats.avgTraversalTimeNs,
+                                bgId, (double)bgWorkerStats.numMovedItems/(double)bgWorkerStats.numTraversals)
+              << std::endl;
+        }
+        bgId++;
+
+    }
+    bgId = 1;
+    for (auto &bgWorkerStats : backgroundPromoStats) {
+        if (bgWorkerStats.numMovedItems > 0) {
+          out << folly::sformat(" == Background Promoter Threads ==") << std::endl;
+          out << folly::sformat("Background Promoter Thread {} Promoted Items: {:,}\n"
+                                "Background Promoter Thread {} Traversals: {:,}\n"
+                                "Background Promoter Thread {} Run Count: {:,}\n"
+                                "Background Promoter Thread {} Avg Time Per Traversal in ns: {:,}\n"
+                                "Background Promoter Thread {} Avg Items Promoted: {:.2f}",
+                                bgId, bgWorkerStats.numMovedItems,
+                                bgId, bgWorkerStats.numTraversals,
+                                bgId, bgWorkerStats.runCount,
+                                bgId, bgWorkerStats.avgTraversalTimeNs,
+                                bgId, (double)bgWorkerStats.numMovedItems/(double)bgWorkerStats.numTraversals)
+              << std::endl;
+        }
+        bgId++;
+
+    }
     if (numCacheGets > 0) {
       out << folly::sformat("Cache Gets    : {:,}", numCacheGets) << std::endl;
       out << folly::sformat("Hit Ratio     : {:6.2f}%", overallHitRatio)
@@ -268,8 +282,7 @@ struct Stats {
                    const util::PercentileStats::Estimates& latency) {
               auto fmtLatency = [&out, &cat](folly::StringPiece pct,
                                              double val) {
-                out << folly::sformat("{:20} {:8} : {:>10.2f} ns\n", cat, pct,
-                                      val);
+                out << folly::sformat("{:20} {:8} in ns: {:>10.2f}\n", cat, pct, val);
               };
 
               fmtLatency("p50", latency.p50);
@@ -284,43 +297,37 @@ struct Stats {
 
         printLatencies("Cache Find API latency", cacheFindLatencyNs);
         printLatencies("Cache Allocate API latency", cacheAllocateLatencyNs);
-        printLatencies("Cache Background Eviction API latency", cacheBgEvictLatencyNs);
-        printLatencies("Cache Background Promotion API latency", cacheBgPromoteLatencyNs);
+        printLatencies("Cache Background Eviction latency", cacheBgEvictLatencyNs);
+        printLatencies("Cache Background Promotion latency", cacheBgPromoteLatencyNs);
       }
     }
 
-    if (!backgroundEvictionClasses.empty() &&
-        backgndEvicStats.nEvictedItems > 0) {
-      out << "== Class Background Eviction Counters Map ==" << std::endl;
-      foreachAC(backgroundEvictionClasses,
-                [&](auto tid, auto pid, auto cid, auto evicted) {
-                  out << folly::sformat("tid{:2} pid{:2} cid{:4} evicted: {:4}",
-                    tid, pid, cid, evicted) << std::endl;
-                });
-
-      out << folly::sformat("Background Evicted Items : {:,}",
-                            backgndEvicStats.nEvictedItems)
-          << std::endl;
-      out << folly::sformat("Background Evictor Traversals : {:,}",
-                            backgndEvicStats.nTraversals)
-          << std::endl;
+    uint64_t totalbgevicted = 0;
+    uint64_t totalpromoted = 0;
+    for (int i = 0; i < backgroundEvictorStats.size(); i++) {
+        totalbgevicted += backgroundEvictorStats[i].numMovedItems;
     }
-
-    if (!backgroundPromotionClasses.empty() &&
-        backgndPromoStats.nPromotedItems > 0) {
+    for (int i = 0; i < backgroundPromoStats.size(); i++) {
+        totalpromoted += backgroundPromoStats[i].numMovedItems;
+    }
+    if (!backgroundEvictionClasses.empty() && totalbgevicted > 0 ) {
+      out << "== Class Background Eviction Counters Map ==" << std::endl;
+      foreachAC(backgroundEvictionClasses, [&](auto tid, auto pid, auto cid, auto evicted){
+        if (evicted > 0) {
+          out << folly::sformat("tid{:2} pid{:2} cid{:4} evicted: {:4}",
+            tid, pid, cid, evicted) << std::endl;
+        }
+      });
+    }
+    
+    if (!backgroundPromotionClasses.empty() && totalpromoted) {
       out << "== Class Background Promotion Counters Map ==" << std::endl;
-      foreachAC(backgroundPromotionClasses,
-                [&](auto tid, auto pid, auto cid, auto promoted) {
-                  out << folly::sformat("tid{:2} pid{:2} cid{:4} promoted: {:4}",
-                    pid, cid, promoted) << std::endl;
-                });
-
-      out << folly::sformat("Background Promoted Items : {:,}",
-                            backgndPromoStats.nPromotedItems)
-          << std::endl;
-      out << folly::sformat("Background Promoter Traversals : {:,}",
-                            backgndPromoStats.nTraversals)
-          << std::endl;
+      foreachAC(backgroundPromotionClasses, [&](auto tid, auto pid, auto cid, auto promoted){
+        if (promoted > 0) {
+          out << folly::sformat("tid{:2} pid{:2} cid{:4} promoted: {:4}",
+            tid, pid, cid, promoted) << std::endl;
+        }
+      });
     }
 
     if (reaperStats.numReapedItems > 0) {
@@ -376,15 +383,15 @@ struct Stats {
 
       double devWriteAmp =
           pctFn(numNvmNandBytesWritten, numNvmBytesWritten) / 100.0;
-      out << folly::sformat("NVM bytes written (physical)  : {:6.2f} GB\n",
+      out << folly::sformat("NVM bytes written (physical) in GB : {:6.2f}\n",
                             numNvmBytesWritten / GB);
-      out << folly::sformat("NVM bytes written (logical)   : {:6.2f} GB\n",
+      out << folly::sformat("NVM bytes written (logical) in GB  : {:6.2f}\n",
                             numNvmLogicalBytesWritten / GB);
-      out << folly::sformat("NVM bytes written (nand)      : {:6.2f} GB\n",
+      out << folly::sformat("NVM bytes written (nand) in GB     : {:6.2f}\n",
                             numNvmNandBytesWritten / GB);
-      out << folly::sformat("NVM app write amplification   : {:6.2f}\n",
+      out << folly::sformat("NVM app write amplification        : {:6.2f}\n",
                             appWriteAmp);
-      out << folly::sformat("NVM dev write amplification   : {:6.2f}\n",
+      out << folly::sformat("NVM dev write amplification        : {:6.2f}\n",
                             devWriteAmp);
     }
     const double putSuccessPct =
@@ -393,62 +400,57 @@ struct Stats {
                     numNvmPuts);
     const double cleanEvictPct = pctFn(numNvmCleanEvict, numNvmEvictions);
     const double getCoalescedPct = pctFn(numNvmGetCoalesced, numNvmGets);
-    out << folly::sformat("{:14}: {:15,}, {:10}: {:6.2f}%",
-                          "NVM Gets",
-                          numNvmGets,
-                          "Coalesced",
-                          getCoalescedPct)
+    out << folly::sformat("{:30}: {:10,}\n"
+                          "{:30}: {:10.2f}",
+                          "NVM Gets", numNvmGets,
+                          "NVM Coalesced in pct", getCoalescedPct)
         << std::endl;
     out << folly::sformat(
-               "{:14}: {:15,}, {:10}: {:6.2f}%, {:8}: {:6.2f}%, {:16}: "
-               "{:8,}, {:16}: {:8,}",
-               "NVM Puts",
-               numNvmPuts,
-               "Success",
-               putSuccessPct,
-               "Clean",
-               pctFn(numNvmPutFromClean, numNvmPuts),
-               "AbortsFromDel",
-               numNvmAbortedPutOnTombstone,
-               "AbortsFromGet",
-               numNvmAbortedPutOnInflightGet)
+               "{:30}: {:10,}\n"
+               "{:30}: {:10.2f}\n"
+               "{:30}: {:10.2f}\n"
+               "{:30}: {:10,}\n"
+               "{:30}: {:10,}",
+               "NVM Puts", numNvmPuts,
+               "NVM Puts Success in pct", putSuccessPct,
+               "NVM Puts from Clean in pct", pctFn(numNvmPutFromClean, numNvmPuts),
+               "NVM AbortsFromDel", numNvmAbortedPutOnTombstone,
+               "NVM AbortsFromGet", numNvmAbortedPutOnInflightGet)
         << std::endl;
     out << folly::sformat(
-               "{:14}: {:15,}, {:10}: {:6.2f}%, {:8}: {:7,},"
-               " {:16}: {:8,}",
-               "NVM Evicts",
-               numNvmEvictions,
-               "Clean",
-               cleanEvictPct,
-               "Unclean",
-               numNvmUncleanEvict,
-               "Double",
-               numNvmCleanDoubleEvict)
+               "{:30}: {:10,}\n"
+               "{:30}: {:10.2f}\n"
+               "{:30}: {:10,}\n"
+               "{:30}: {:10,}",
+               "NVM Evicts", numNvmEvictions,
+               "NVM Clean Evicts in pct", cleanEvictPct,
+               "NVM Unclean Evicts", numNvmUncleanEvict,
+               "NVM Clean Double Evicts", numNvmCleanDoubleEvict)
         << std::endl;
     const double skippedDeletesPct = pctFn(numNvmSkippedDeletes, numNvmDeletes);
-    out << folly::sformat("{:14}: {:15,} {:14}: {:6.2f}%",
-                          "NVM Deletes",
-                          numNvmDeletes,
-                          "Skipped Deletes",
-                          skippedDeletesPct)
+    out << folly::sformat("{:30}: {:10,}\n"
+                          "{:30}: {:10.2f}",
+                          "NVM Deletes", numNvmDeletes,
+                          "NVM Skipped Deletes in pct", skippedDeletesPct)
         << std::endl;
     if (numNvmExceededMaxRetry > 0) {
-      out << folly::sformat("{}: {}", "NVM max read retry reached",
+      out << folly::sformat("{:30}: {:10,}", "NVM max read retry reached",
                             numNvmExceededMaxRetry)
           << std::endl;
     }
 
     if (slabsReleased > 0) {
       out << folly::sformat(
-                 "Released {:,} slabs\n"
-                 "  Moves     : attempts: {:10,}, success: {:6.2f}%\n"
-                 "  Evictions : attempts: {:10,}, success: {:6.2f}%",
+                 "Released slabs: {:,}\n"
+                 "Slab Move attempts: {:10,}\n"
+                 "Slab Move success in pct: {:6.2f}\n"
+                 "Slab Eviction attempts: {:10,}\n"
+                 "Slab Eviction success in pct: {:6.2f}",
                  slabsReleased,
                  moveAttemptsForSlabRelease,
                  pctFn(moveSuccessesForSlabRelease, moveAttemptsForSlabRelease),
                  evictionAttemptsForSlabRelease,
-                 pctFn(evictionSuccessesForSlabRelease,
-                       evictionAttemptsForSlabRelease))
+                 pctFn(evictionSuccessesForSlabRelease, evictionAttemptsForSlabRelease))
           << std::endl;
     }
 
@@ -466,8 +468,13 @@ struct Stats {
     }
 
     if (numCacheEvictions > 0) {
-      out << folly::sformat("Total evictions executed {:,}", numCacheEvictions)
+      out << folly::sformat("Total evictions executed  : {:10,}", numCacheEvictions)
               << std::endl;
+      out << folly::sformat("Total background evictions: {:10,}", totalbgevicted)
+              << std::endl;
+    }
+    if (totalpromoted > 0) {
+      out << folly::sformat("Total promotions          : {:10,}", totalpromoted) << std::endl;
     }
   }
 

--- a/cachelib/cachebench/util/CacheConfig.cpp
+++ b/cachelib/cachebench/util/CacheConfig.cpp
@@ -51,6 +51,7 @@ CacheConfig::CacheConfig(const folly::dynamic& configJson) {
   JSONSetVal(configJson, useCombinedLockForIterators);
   
   JSONSetVal(configJson, insertToFirstFreeTier);
+  JSONSetVal(configJson, noOnlineEviction);
 
   JSONSetVal(configJson, lru2qHotPct);
   JSONSetVal(configJson, lru2qColdPct);

--- a/cachelib/cachebench/util/CacheConfig.cpp
+++ b/cachelib/cachebench/util/CacheConfig.cpp
@@ -177,7 +177,13 @@ std::shared_ptr<BackgroundMoverStrategy> CacheConfig::getBackgroundEvictorStrate
   if (backgroundEvictorIntervalMilSec == 0) {
     return nullptr;
   }
-  return std::make_shared<FreeThresholdStrategy>(lowEvictionAcWatermark, highEvictionAcWatermark, maxEvictionBatch, minEvictionBatch);
+  if (backgroundEvictorStrategy == "threshold") {
+    return std::make_shared<FreeThresholdStrategy>(lowEvictionAcWatermark, highEvictionAcWatermark, maxEvictionBatch, minEvictionBatch);
+  } else if (backgroundEvictorStrategy == "fixed") {
+    return std::make_shared<DefaultBackgroundMoverStrategy>(maxEvictionBatch, highEvictionAcWatermark);
+  } else {
+    return std::make_shared<FreeThresholdStrategy>(lowEvictionAcWatermark, highEvictionAcWatermark, maxEvictionBatch, minEvictionBatch);
+  }
 }
 
 std::shared_ptr<BackgroundMoverStrategy> CacheConfig::getBackgroundPromoterStrategy() const {

--- a/cachelib/cachebench/util/CacheConfig.h
+++ b/cachelib/cachebench/util/CacheConfig.h
@@ -99,6 +99,7 @@ struct CacheConfig : public JSONConfig {
   bool useCombinedLockForIterators{true};
   
   bool insertToFirstFreeTier{false};
+  bool noOnlineEviction{false};
 
   // LRU param
   uint64_t lruIpSpec{0};


### PR DESCRIPTION
The main improvements are:
1. bulk add/remove from mmContainer
2. bulk eviction
3. better scheduling of background threads and calculating batch sizes
4. improved stats (including those from https://github.com/guptask/CacheLib/tree/dsa_bgknd_bulk_evictions)
5. ability for background workers to evict/promote without mark moving bit - we can use acquire instead

The results are - nearly 20% improvement in multi-tier (develop branch) performance with this config:
[simple_tiers_test_bg.txt](https://github.com/pmem/CacheLib/files/12562850/simple_tiers_test_bg.txt)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/CacheLib/96)
<!-- Reviewable:end -->
